### PR TITLE
Wire default spin duration

### DIFF
--- a/app.js
+++ b/app.js
@@ -317,6 +317,7 @@ async function initializeApp() {
         }
 
         initWheel(document.getElementById("wheel"));
+        setSpinDurationMs(spinDurationMsDefault);
         registerSpinCallbacks({
             onTick: function onTick() { playTick(); triggerPointerTap(); },
             onStop: function onStop(winnerIndex) {


### PR DESCRIPTION
## Summary
- initialize the wheel with the existing default spin duration constant so the control is seeded before randomization

## Testing
- npx eslint . (fails: missing eslint configuration file)

------
https://chatgpt.com/codex/tasks/task_e_68c8bfd4b9f88327a2a1880e4c3fa901