### PR TITLE
Extract hearts UI helpers into dedicated module

### DIFF
--- a/game.js
+++ b/game.js
@@ -9,11 +9,13 @@ import { populateRevealCard, showGameOver, showWinningCard } from "./lastCard.js
 import {
     showScreen,
     setWheelControlToStop,
-    setWheelControlToStartGame,
+    setWheelControlToStartGame
+} from "./ui.js";
+import {
     renderHearts,
     animateHeartGainFromReveal,
     animateHeartLossAtHeartsBar
-} from "./ui.js";
+} from "./hearts.js";
 import {
     initWheel,
     setWheelLabels,

--- a/hearts.js
+++ b/hearts.js
@@ -1,0 +1,115 @@
+/* global document */
+
+const ElementId = Object.freeze({
+    HEARTS_BAR: "hearts-bar"
+});
+
+const AttributeName = Object.freeze({
+    DATA_COUNT: "data-count",
+    ARIA_LABEL: "aria-label",
+    ARIA_HIDDEN: "aria-hidden"
+});
+
+const AttributeValue = Object.freeze({
+    TRUE: "true"
+});
+
+const ElementTagName = Object.freeze({
+    SPAN: "span"
+});
+
+const HeartClassName = Object.freeze({
+    HEART: "heart",
+    HEART_GAIN: "heart gain"
+});
+
+const HeartSelector = Object.freeze({
+    HEART: ".heart"
+});
+
+const HeartSymbol = "❤️";
+
+const TextContent = Object.freeze({
+    EMPTY: "",
+    HEART_LABEL_SUFFIX: " hearts"
+});
+
+const NumericBase = Object.freeze({
+    DECIMAL: 10
+});
+
+function setMetadataAttributes(heartsBarElement, totalHearts) {
+    const totalLabel = `${totalHearts}${TextContent.HEART_LABEL_SUFFIX}`;
+    heartsBarElement.setAttribute(AttributeName.DATA_COUNT, String(totalHearts));
+    heartsBarElement.setAttribute(AttributeName.ARIA_LABEL, totalLabel);
+    heartsBarElement.title = totalLabel;
+}
+
+function appendHeartElements(heartsBarElement, totalHearts) {
+    heartsBarElement.innerHTML = TextContent.EMPTY;
+    for (let heartIndex = 0; heartIndex < totalHearts; heartIndex += 1) {
+        const heartElement = document.createElement(ElementTagName.SPAN);
+        heartElement.className = HeartClassName.HEART;
+        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+        heartElement.textContent = HeartSymbol;
+        heartsBarElement.appendChild(heartElement);
+    }
+}
+
+function appendGainHearts(heartsBarElement, heartsToAdd) {
+    for (let heartGainIndex = 0; heartGainIndex < heartsToAdd; heartGainIndex += 1) {
+        const heartElement = document.createElement(ElementTagName.SPAN);
+        heartElement.className = HeartClassName.HEART_GAIN;
+        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+        heartElement.textContent = HeartSymbol;
+        heartsBarElement.appendChild(heartElement);
+    }
+}
+
+function removeHeartElements(heartsBarElement, heartsToRemove) {
+    for (let removalIndex = 0; removalIndex < heartsToRemove; removalIndex += 1) {
+        const heartElement = heartsBarElement.querySelector(HeartSelector.HEART);
+        if (!heartElement) {
+            return;
+        }
+        heartsBarElement.removeChild(heartElement);
+    }
+}
+
+export function renderHearts(count, options = {}) {
+    const { animate = false } = options;
+    const heartsBarElement = document.getElementById(ElementId.HEARTS_BAR);
+    if (!heartsBarElement) {
+        return;
+    }
+
+    const previousCount = parseInt(
+        heartsBarElement.getAttribute(AttributeName.DATA_COUNT) || "0",
+        NumericBase.DECIMAL
+    );
+    const totalHearts = Math.max(0, Math.floor(count || 0));
+
+    if (!animate || previousCount === 0) {
+        appendHeartElements(heartsBarElement, totalHearts);
+        setMetadataAttributes(heartsBarElement, totalHearts);
+        return;
+    }
+
+    const delta = totalHearts - previousCount;
+    if (delta > 0) {
+        appendGainHearts(heartsBarElement, delta);
+    } else if (delta < 0) {
+        const heartsToRemove = Math.min(previousCount, -delta);
+        removeHeartElements(heartsBarElement, heartsToRemove);
+    }
+
+    setMetadataAttributes(heartsBarElement, totalHearts);
+}
+
+export function animateHeartGainFromReveal() {
+    /* handled in CSS or implemented elsewhere */
+}
+
+export function animateHeartLossAtHeartsBar() {
+    /* handled in CSS or implemented elsewhere */
+}

--- a/ui.js
+++ b/ui.js
@@ -1,68 +1,42 @@
-/* File: ui.js */
 /* global document */
 import { SCREEN_ALLERGY, SCREEN_WHEEL } from "./constants.js";
 
-/* exclusive screens */
+const ElementId = Object.freeze({
+    REVEAL_SECTION: "reveal"
+});
+
+const AttributeName = Object.freeze({
+    DATA_SCREEN: "data-screen",
+    ARIA_HIDDEN: "aria-hidden"
+});
+
+const AttributeValue = Object.freeze({
+    TRUE: "true"
+});
+
 export function showScreen(screenName) {
     const bodyElement = document.body;
-    const revealElement = document.getElementById("reveal");
-
-    if (screenName === SCREEN_ALLERGY) {
-        bodyElement.setAttribute("data-screen", SCREEN_ALLERGY);
-        if (revealElement) revealElement.setAttribute("aria-hidden", "true");
-    } else if (screenName === SCREEN_WHEEL) {
-        bodyElement.setAttribute("data-screen", SCREEN_WHEEL);
-        if (revealElement) revealElement.setAttribute("aria-hidden", "true");
-    }
-}
-
-/* stop button visual state helpers (mirrored in app.js text switch) */
-export function setWheelControlToStop() { /* no-op for API symmetry */ }
-export function setWheelControlToStartGame() { /* no-op for API symmetry */ }
-
-/* ---------- Hearts UI ---------- */
-export function renderHearts(count, options = {}) {
-    const { animate = false } = options;
-    const heartsBar = document.getElementById("hearts-bar");
-    if (!heartsBar) return;
-
-    const previousCount = parseInt(heartsBar.getAttribute("data-count") || "0", 10);
-    const total = Math.max(0, Math.floor(count || 0));
-
-    if (!animate || previousCount === 0) {
-        heartsBar.innerHTML = "";
-        for (let index = 0; index < total; index++) {
-            const span = document.createElement("span");
-            span.className = "heart";
-            span.setAttribute("aria-hidden", "true");
-            span.textContent = "❤️";
-            heartsBar.appendChild(span);
-        }
-        heartsBar.setAttribute("data-count", String(total));
-        heartsBar.setAttribute("aria-label", total + " hearts");
-        heartsBar.title = total + " hearts";
+    if (!bodyElement) {
         return;
     }
 
-    const delta = total - previousCount;
-    if (delta > 0) {
-        for (let i = 0; i < delta; i++) {
-            const span = document.createElement("span");
-            span.className = "heart gain";
-            span.setAttribute("aria-hidden", "true");
-            span.textContent = "❤️";
-            heartsBar.appendChild(span);
-        }
-    } else if (delta < 0) {
-        const toRemove = Math.min(previousCount, -delta);
-        for (let i = 0; i < toRemove; i++) {
-            const child = heartsBar.querySelector(".heart");
-            if (child) heartsBar.removeChild(child);
-        }
+    const revealElement = document.getElementById(ElementId.REVEAL_SECTION);
+
+    if (screenName === SCREEN_ALLERGY) {
+        bodyElement.setAttribute(AttributeName.DATA_SCREEN, SCREEN_ALLERGY);
+    } else if (screenName === SCREEN_WHEEL) {
+        bodyElement.setAttribute(AttributeName.DATA_SCREEN, SCREEN_WHEEL);
     }
-    heartsBar.setAttribute("data-count", String(total));
+
+    if (revealElement) {
+        revealElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+    }
 }
 
-/* small helpers for hearts animations (no-op stubs to keep API consistent with app.js) */
-export function animateHeartGainFromReveal() { /* handled in CSS or implemented elsewhere */ }
-export function animateHeartLossAtHeartsBar() { /* handled in CSS or implemented elsewhere */ }
+export function setWheelControlToStop() {
+    /* no-op for API symmetry */
+}
+
+export function setWheelControlToStartGame() {
+    /* no-op for API symmetry */
+}


### PR DESCRIPTION
## Summary
- move heart rendering and animation stub helpers into a dedicated `hearts.js` module
- limit `ui.js` to shared screen helpers now that hearts code moved out
- update `game.js` to import the hearts helpers from their new home

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8dcb6f22083278b115062188471b7