### PR TITLE
Refactor result card interactions into class

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ import {
 import { Board } from "./board.js";
 import { NormalizationEngine, loadJson, pickRandomUnique } from "./utils.js";
 import { AllergenCard } from "./firstCard.js";
-import { populateRevealCard, showGameOver, showWinningCard } from "./lastCard.js";
+import { ResultCard, ElementId as ResultCardElementId } from "./lastCard.js";
 import { renderHearts, animateHeartGainFromReveal, animateHeartLossAtHeartsBar } from "./hearts.js";
 import { primeAudioOnFirstGesture, playTick, playSiren, playNomNom, playWin } from "./audio.js";
 import { showScreen, setWheelControlToStop, setWheelControlToStartGame } from "./ui.js";
@@ -114,11 +114,21 @@ const firstCardPresenter = new AllergenCard({
     }
 });
 
-const revealCardPresenter = {
-    populateRevealCard,
-    showGameOver,
-    showWinningCard
-};
+const revealCardPresenter = new ResultCard({
+    documentReference: document,
+    revealSectionElement: document.getElementById(ResultCardElementId.REVEAL_SECTION),
+    dishTitleElement: document.getElementById(ResultCardElementId.DISH_TITLE),
+    dishCuisineElement: document.getElementById(ResultCardElementId.DISH_CUISINE),
+    resultBannerElement: document.getElementById(ResultCardElementId.RESULT_BANNER),
+    resultTextElement: document.getElementById(ResultCardElementId.RESULT_TEXT),
+    ingredientsContainerElement: document.getElementById(ResultCardElementId.INGREDIENTS_CONTAINER),
+    faceSvgElement: document.getElementById(ResultCardElementId.FACE_SVG),
+    gameOverSectionElement: document.getElementById(ResultCardElementId.GAME_OVER_SECTION),
+    normalizationEngine: board.normalizationEngine,
+    allergensCatalog: board.allergensCatalog,
+    cuisineToFlagMap: new Map(),
+    ingredientEmojiByName: new Map()
+});
 
 const heartsPresenter = {
     renderHearts,

--- a/lastCard.js
+++ b/lastCard.js
@@ -1,6 +1,6 @@
 /* global document */
 
-const ElementId = Object.freeze({
+export const ElementId = Object.freeze({
     REVEAL_SECTION: "reveal",
     DISH_TITLE: "dish-title",
     DISH_CUISINE: "dish-cuisine",
@@ -51,163 +51,277 @@ const ValueType = Object.freeze({
     FUNCTION: typeof Function
 });
 
-export function populateRevealCard({
-    dish,
-    selectedAllergenToken,
-    selectedAllergenLabel,
-    normalizationEngine,
-    allergensCatalog,
-    cuisineToFlagMap,
-    ingredientEmojiByName
-}) {
-    const revealSection = document.getElementById(ElementId.REVEAL_SECTION);
-    const dishTitleElement = document.getElementById(ElementId.DISH_TITLE);
-    const dishCuisineElement = document.getElementById(ElementId.DISH_CUISINE);
-    const resultBannerElement = document.getElementById(ElementId.RESULT_BANNER);
-    const resultTextElement = document.getElementById(ElementId.RESULT_TEXT);
-    const ingredientsContainer = document.getElementById(ElementId.INGREDIENTS_CONTAINER);
-    const faceSvg = document.getElementById(ElementId.FACE_SVG);
-
-    const safeDish = dish || {};
-    const dishEmoji = safeDish.emoji || TextContent.EMPTY;
-    const dishNameCandidates = [safeDish.name, safeDish.title, safeDish.label, safeDish.id];
-    const dishNameText = dishNameCandidates.find((value) => value) || TextContent.EMPTY;
-    dishTitleElement.textContent = dishEmoji
-        ? `${dishEmoji}${TextContent.SPACE}${dishNameText}`
-        : dishNameText;
-
-    const cuisineText = safeDish.cuisine || TextContent.EMPTY;
-    let cuisineFlagEmoji = TextContent.EMPTY;
-    if (cuisineToFlagMap && typeof cuisineToFlagMap.get === ValueType.FUNCTION && cuisineText) {
-        const cuisineKey = String(cuisineText).trim().toLowerCase();
-        cuisineFlagEmoji = cuisineToFlagMap.get(cuisineKey) || TextContent.EMPTY;
+function normalizeToMap(candidateMap) {
+    if (candidateMap instanceof Map) {
+        return candidateMap;
     }
-    dishCuisineElement.textContent = cuisineText
-        ? (cuisineFlagEmoji
-            ? `${cuisineText}${TextContent.SPACE}${cuisineFlagEmoji}`
-            : cuisineText)
-        : TextContent.EMPTY;
+    if (!candidateMap) {
+        return new Map();
+    }
+    return new Map(candidateMap);
+}
 
-    ingredientsContainer.textContent = TextContent.EMPTY;
+function ensureSet(candidateIterable) {
+    if (candidateIterable instanceof Set) {
+        return candidateIterable;
+    }
+    if (Array.isArray(candidateIterable)) {
+        return new Set(candidateIterable);
+    }
+    if (candidateIterable && typeof candidateIterable[Symbol.iterator] === "function") {
+        return new Set(candidateIterable);
+    }
+    return new Set();
+}
 
-    const emojiByToken = new Map();
-    for (const allergenRecord of allergensCatalog || []) {
-        if (allergenRecord && allergenRecord.token) {
-            emojiByToken.set(allergenRecord.token, allergenRecord.emoji || TextContent.EMPTY);
+export class ResultCard {
+    #documentReference;
+
+    #revealSectionElement;
+
+    #dishTitleElement;
+
+    #dishCuisineElement;
+
+    #resultBannerElement;
+
+    #resultTextElement;
+
+    #ingredientsContainerElement;
+
+    #faceSvgElement;
+
+    #gameOverSectionElement;
+
+    #actionsContainerElement;
+
+    #normalizationEngine;
+
+    #allergensCatalog;
+
+    #cuisineToFlagMap;
+
+    #ingredientEmojiByName;
+
+    #emojiByTokenMap;
+
+    constructor({
+        documentReference = document,
+        revealSectionElement,
+        dishTitleElement,
+        dishCuisineElement,
+        resultBannerElement,
+        resultTextElement,
+        ingredientsContainerElement,
+        faceSvgElement,
+        gameOverSectionElement,
+        normalizationEngine,
+        allergensCatalog,
+        cuisineToFlagMap,
+        ingredientEmojiByName
+    }) {
+        this.#documentReference = documentReference;
+        this.#revealSectionElement = revealSectionElement || null;
+        this.#dishTitleElement = dishTitleElement || null;
+        this.#dishCuisineElement = dishCuisineElement || null;
+        this.#resultBannerElement = resultBannerElement || null;
+        this.#resultTextElement = resultTextElement || null;
+        this.#ingredientsContainerElement = ingredientsContainerElement || null;
+        this.#faceSvgElement = faceSvgElement || null;
+        this.#gameOverSectionElement = gameOverSectionElement || null;
+        this.#actionsContainerElement = this.#revealSectionElement
+            ? this.#revealSectionElement.querySelector(Selector.ACTIONS_CONTAINER)
+            : null;
+
+        this.#normalizationEngine = normalizationEngine || null;
+        this.#allergensCatalog = Array.isArray(allergensCatalog) ? allergensCatalog : [];
+        this.#cuisineToFlagMap = normalizeToMap(cuisineToFlagMap);
+        this.#ingredientEmojiByName = normalizeToMap(ingredientEmojiByName);
+        this.#emojiByTokenMap = this.#buildEmojiByTokenMap(this.#allergensCatalog);
+    }
+
+    updateDataDependencies({
+        normalizationEngine,
+        allergensCatalog,
+        cuisineToFlagMap,
+        ingredientEmojiByName
+    }) {
+        if (normalizationEngine) {
+            this.#normalizationEngine = normalizationEngine;
+        }
+        if (Array.isArray(allergensCatalog)) {
+            this.#allergensCatalog = allergensCatalog;
+            this.#emojiByTokenMap = this.#buildEmojiByTokenMap(allergensCatalog);
+        }
+        if (cuisineToFlagMap) {
+            this.#cuisineToFlagMap = normalizeToMap(cuisineToFlagMap);
+        }
+        if (ingredientEmojiByName) {
+            this.#ingredientEmojiByName = normalizeToMap(ingredientEmojiByName);
         }
     }
 
-    let hasTriggeringIngredient = false;
-    const ingredientList = Array.isArray(safeDish.ingredients) ? safeDish.ingredients : [];
+    populateRevealCard({
+        dish,
+        selectedAllergenToken,
+        selectedAllergenLabel
+    }) {
+        const safeDish = dish || {};
+        const dishEmoji = safeDish.emoji || TextContent.EMPTY;
+        const dishNameCandidates = [safeDish.name, safeDish.title, safeDish.label, safeDish.id];
+        const dishNameText = dishNameCandidates.find((value) => value) || TextContent.EMPTY;
 
-    for (const ingredientName of ingredientList) {
-        const ingredientSpan = document.createElement(ElementTagName.SPAN);
-        ingredientSpan.className = ClassName.INGREDIENT;
-
-        const rawIngredientName = String(ingredientName || TextContent.EMPTY);
-        const loweredIngredientName = rawIngredientName.trim().toLowerCase();
-
-        const tokensForIngredient = normalizationEngine.tokensForIngredient(rawIngredientName);
-
-        let ingredientEmoji = TextContent.EMPTY;
-        if (ingredientEmojiByName && typeof ingredientEmojiByName.get === ValueType.FUNCTION) {
-            ingredientEmoji = ingredientEmojiByName.get(loweredIngredientName) || TextContent.EMPTY;
+        if (this.#dishTitleElement) {
+            this.#dishTitleElement.textContent = dishEmoji
+                ? `${dishEmoji}${TextContent.SPACE}${dishNameText}`
+                : dishNameText;
         }
-        if (!ingredientEmoji) {
-            for (const allergenToken of tokensForIngredient) {
-                const emojiFromToken = emojiByToken.get(allergenToken);
-                if (emojiFromToken) {
-                    ingredientEmoji = emojiFromToken;
-                    break;
+
+        const cuisineText = safeDish.cuisine || TextContent.EMPTY;
+        let cuisineFlagEmoji = TextContent.EMPTY;
+        if (this.#cuisineToFlagMap && typeof this.#cuisineToFlagMap.get === ValueType.FUNCTION && cuisineText) {
+            const cuisineKey = String(cuisineText).trim().toLowerCase();
+            cuisineFlagEmoji = this.#cuisineToFlagMap.get(cuisineKey) || TextContent.EMPTY;
+        }
+        if (this.#dishCuisineElement) {
+            this.#dishCuisineElement.textContent = cuisineText
+                ? (cuisineFlagEmoji
+                    ? `${cuisineText}${TextContent.SPACE}${cuisineFlagEmoji}`
+                    : cuisineText)
+                : TextContent.EMPTY;
+        }
+
+        if (this.#ingredientsContainerElement) {
+            this.#ingredientsContainerElement.textContent = TextContent.EMPTY;
+        }
+
+        let hasTriggeringIngredient = false;
+        const ingredientList = Array.isArray(safeDish.ingredients) ? safeDish.ingredients : [];
+
+        for (const ingredientName of ingredientList) {
+            if (!this.#ingredientsContainerElement) {
+                break;
+            }
+
+            const ingredientSpan = this.#documentReference.createElement(ElementTagName.SPAN);
+            ingredientSpan.className = ClassName.INGREDIENT;
+
+            const rawIngredientName = String(ingredientName || TextContent.EMPTY);
+            const loweredIngredientName = rawIngredientName.trim().toLowerCase();
+
+            const tokensIterable = this.#normalizationEngine
+                && typeof this.#normalizationEngine.tokensForIngredient === ValueType.FUNCTION
+                ? this.#normalizationEngine.tokensForIngredient(rawIngredientName)
+                : [];
+            const tokensForIngredient = ensureSet(tokensIterable);
+
+            let ingredientEmoji = TextContent.EMPTY;
+            if (this.#ingredientEmojiByName && typeof this.#ingredientEmojiByName.get === ValueType.FUNCTION) {
+                ingredientEmoji = this.#ingredientEmojiByName.get(loweredIngredientName) || TextContent.EMPTY;
+            }
+            if (!ingredientEmoji) {
+                for (const allergenToken of tokensForIngredient) {
+                    const emojiFromToken = this.#emojiByTokenMap.get(allergenToken);
+                    if (emojiFromToken) {
+                        ingredientEmoji = emojiFromToken;
+                        break;
+                    }
+                }
+            }
+
+            if (selectedAllergenToken && tokensForIngredient.has(selectedAllergenToken)) {
+                hasTriggeringIngredient = true;
+                ingredientSpan.classList.add(ClassName.BAD);
+                if (!ingredientEmoji) {
+                    ingredientEmoji = this.#emojiByTokenMap.get(selectedAllergenToken) || TextContent.EMPTY;
+                }
+            }
+
+            const textSpan = this.#documentReference.createElement(ElementTagName.SPAN);
+            textSpan.textContent = rawIngredientName;
+            ingredientSpan.appendChild(textSpan);
+
+            if (ingredientEmoji) {
+                const emojiSpan = this.#documentReference.createElement(ElementTagName.SPAN);
+                emojiSpan.className = ClassName.EMOJI_LARGE;
+                emojiSpan.textContent = ingredientEmoji;
+                ingredientSpan.appendChild(emojiSpan);
+            }
+
+            this.#ingredientsContainerElement.appendChild(ingredientSpan);
+        }
+
+        if (this.#resultBannerElement && this.#resultTextElement) {
+            if (hasTriggeringIngredient) {
+                this.#resultBannerElement.classList.remove(ClassName.OK);
+                this.#resultBannerElement.classList.add(ClassName.BAD);
+                this.#resultTextElement.textContent = `${TextContent.RESULT_BAD_PREFIX}${selectedAllergenLabel}`;
+                if (this.#faceSvgElement) {
+                    this.#faceSvgElement.hidden = false;
+                }
+            } else {
+                this.#resultBannerElement.classList.remove(ClassName.BAD);
+                this.#resultBannerElement.classList.add(ClassName.OK);
+                this.#resultTextElement.textContent = TextContent.SAFE_TO_EAT;
+                if (this.#faceSvgElement) {
+                    this.#faceSvgElement.hidden = true;
                 }
             }
         }
 
-        if (tokensForIngredient.has(selectedAllergenToken)) {
-            hasTriggeringIngredient = true;
-            ingredientSpan.classList.add(ClassName.BAD);
-            if (!ingredientEmoji) {
-                ingredientEmoji = emojiByToken.get(selectedAllergenToken) || TextContent.EMPTY;
+        if (this.#revealSectionElement) {
+            this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+        }
+
+        return { hasTriggeringIngredient };
+    }
+
+    showGameOver() {
+        if (this.#gameOverSectionElement) {
+            this.#gameOverSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+            return { isDisplayed: true };
+        }
+        return { isDisplayed: false };
+    }
+
+    showWinningCard() {
+        if (!this.#revealSectionElement || !this.#dishTitleElement || !this.#resultBannerElement
+            || !this.#resultTextElement || !this.#ingredientsContainerElement || !this.#actionsContainerElement) {
+            return { restartButton: null, isDisplayed: false };
+        }
+
+        this.#dishTitleElement.textContent = TextContent.WIN_TITLE;
+        if (this.#dishCuisineElement) {
+            this.#dishCuisineElement.textContent = TextContent.EMPTY;
+        }
+
+        this.#resultBannerElement.classList.remove(ClassName.BAD);
+        this.#resultBannerElement.classList.add(ClassName.OK);
+        this.#resultTextElement.textContent = TextContent.WIN_MESSAGE;
+        if (this.#faceSvgElement) {
+            this.#faceSvgElement.hidden = true;
+        }
+
+        this.#ingredientsContainerElement.textContent = TextContent.EMPTY;
+
+        this.#actionsContainerElement.textContent = TextContent.EMPTY;
+        const restartButton = this.#documentReference.createElement(ElementTagName.BUTTON);
+        restartButton.className = ClassName.BUTTON_PRIMARY;
+        restartButton.id = ElementId.WIN_RESTART_BUTTON;
+        restartButton.textContent = TextContent.RESTART_BUTTON_LABEL;
+        this.#actionsContainerElement.appendChild(restartButton);
+
+        this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+        return { restartButton, isDisplayed: true };
+    }
+
+    #buildEmojiByTokenMap(allergensCatalog) {
+        const emojiMap = new Map();
+        for (const allergenRecord of allergensCatalog || []) {
+            if (allergenRecord && allergenRecord.token) {
+                emojiMap.set(allergenRecord.token, allergenRecord.emoji || TextContent.EMPTY);
             }
         }
-
-        const textSpan = document.createElement(ElementTagName.SPAN);
-        textSpan.textContent = rawIngredientName;
-        ingredientSpan.appendChild(textSpan);
-
-        if (ingredientEmoji) {
-            const emojiSpan = document.createElement(ElementTagName.SPAN);
-            emojiSpan.className = ClassName.EMOJI_LARGE;
-            emojiSpan.textContent = ingredientEmoji;
-            ingredientSpan.appendChild(emojiSpan);
-        }
-
-        ingredientsContainer.appendChild(ingredientSpan);
+        return emojiMap;
     }
-
-    if (hasTriggeringIngredient) {
-        resultBannerElement.classList.remove(ClassName.OK);
-        resultBannerElement.classList.add(ClassName.BAD);
-        resultTextElement.textContent = `${TextContent.RESULT_BAD_PREFIX}${selectedAllergenLabel}`;
-        if (faceSvg) {
-            faceSvg.hidden = false;
-        }
-    } else {
-        resultBannerElement.classList.remove(ClassName.BAD);
-        resultBannerElement.classList.add(ClassName.OK);
-        resultTextElement.textContent = TextContent.SAFE_TO_EAT;
-        if (faceSvg) {
-            faceSvg.hidden = true;
-        }
-    }
-
-    if (revealSection) {
-        revealSection.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
-    }
-
-    return { hasTriggeringIngredient };
-}
-
-export function showGameOver() {
-    const gameoverSection = document.getElementById(ElementId.GAME_OVER_SECTION);
-    if (gameoverSection) {
-        gameoverSection.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
-    }
-}
-
-export function showWinningCard() {
-    const revealSection = document.getElementById(ElementId.REVEAL_SECTION);
-    const dishTitleElement = document.getElementById(ElementId.DISH_TITLE);
-    const dishCuisineElement = document.getElementById(ElementId.DISH_CUISINE);
-    const resultBannerElement = document.getElementById(ElementId.RESULT_BANNER);
-    const resultTextElement = document.getElementById(ElementId.RESULT_TEXT);
-    const ingredientsContainer = document.getElementById(ElementId.INGREDIENTS_CONTAINER);
-    const faceSvg = document.getElementById(ElementId.FACE_SVG);
-    const actionsContainer = revealSection ? revealSection.querySelector(Selector.ACTIONS_CONTAINER) : null;
-
-    if (!revealSection || !dishTitleElement || !resultBannerElement || !resultTextElement || !ingredientsContainer || !actionsContainer) {
-        return null;
-    }
-
-    dishTitleElement.textContent = TextContent.WIN_TITLE;
-    dishCuisineElement.textContent = TextContent.EMPTY;
-
-    resultBannerElement.classList.remove(ClassName.BAD);
-    resultBannerElement.classList.add(ClassName.OK);
-    resultTextElement.textContent = TextContent.WIN_MESSAGE;
-    if (faceSvg) {
-        faceSvg.hidden = true;
-    }
-
-    ingredientsContainer.textContent = TextContent.EMPTY;
-
-    actionsContainer.textContent = TextContent.EMPTY;
-    const restartButton = document.createElement(ElementTagName.BUTTON);
-    restartButton.className = ClassName.BUTTON_PRIMARY;
-    restartButton.id = ElementId.WIN_RESTART_BUTTON;
-    restartButton.textContent = TextContent.RESTART_BUTTON_LABEL;
-    actionsContainer.appendChild(restartButton);
-
-    revealSection.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
-    return restartButton;
 }


### PR DESCRIPTION
## Summary
- encapsulate reveal card behaviors inside a ResultCard class with injected DOM and data dependencies
- instantiate the ResultCard presenter in the app bootstrap and supply it to the game controller
- adjust the game controller to synchronize presenter data and use the new return values during play

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8eaaf7df4832780ab27aa04ccf628