### PR TITLE
Refactor state management into class

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,25 +1,7 @@
 import { GameController } from "./game.js";
 import { Wheel } from "./wheel.js";
 import { createListenerBinder } from "./listeners.js";
-import {
-    initializeState,
-    setBoard,
-    getBoard,
-    setSelectedAllergen,
-    clearSelectedAllergen,
-    getSelectedAllergenToken,
-    getSelectedAllergenLabel,
-    hasSelectedAllergen,
-    setWheelCandidates,
-    resetWheelCandidates,
-    getWheelCandidateDishes,
-    getWheelCandidateLabels,
-    setHeartsCount,
-    incrementHeartsCount,
-    decrementHeartsCount,
-    getInitialHeartsCount,
-    setStopButtonMode
-} from "./state.js";
+import { StateManager } from "./state.js";
 import { Board } from "./board.js";
 import { NormalizationEngine, loadJson, pickRandomUnique } from "./utils.js";
 import { AllergenCard } from "./firstCard.js";
@@ -51,10 +33,13 @@ const FirstCardElementId = Object.freeze({
     BADGE_CONTAINER: "sel-badges"
 });
 
+const stateManager = new StateManager();
+
 const listenerBinder = createListenerBinder({
     controlElementId: ControlElementId,
     attributeName: AttributeName,
-    documentReference: document
+    documentReference: document,
+    stateManager
 });
 
 const wheel = new Wheel();
@@ -64,25 +49,6 @@ const board = new Board({
     dishesCatalog: [],
     normalizationEngine: new NormalizationEngine([])
 });
-
-const stateManager = {
-    setBoard,
-    getBoard,
-    setSelectedAllergen,
-    clearSelectedAllergen,
-    getSelectedAllergenToken,
-    getSelectedAllergenLabel,
-    hasSelectedAllergen,
-    setWheelCandidates,
-    resetWheelCandidates,
-    getWheelCandidateDishes,
-    getWheelCandidateLabels,
-    setHeartsCount,
-    incrementHeartsCount,
-    decrementHeartsCount,
-    getInitialHeartsCount,
-    setStopButtonMode
-};
 
 const firstCardPresenter = new AllergenCard({
     listContainerElement: document.getElementById(FirstCardElementId.LIST_CONTAINER),
@@ -94,12 +60,10 @@ const firstCardPresenter = new AllergenCard({
 
         const selectedLabel = allergenDescriptor.label || allergenDescriptor.token;
 
-        if (stateManager.setSelectedAllergen) {
-            stateManager.setSelectedAllergen({
-                token: allergenDescriptor.token,
-                label: selectedLabel
-            });
-        }
+        stateManager.setSelectedAllergen({
+            token: allergenDescriptor.token,
+            label: selectedLabel
+        });
 
         const startButtonElement = document.getElementById(ControlElementId.START_BUTTON);
         if (startButtonElement) {
@@ -174,7 +138,7 @@ const gameController = new GameController({
     pickRandomUnique
 });
 
-initializeState();
+stateManager.initialize();
 
 window.addEventListener(BrowserEventName.DOM_CONTENT_LOADED, () => {
     gameController.bootstrap();

--- a/listeners.js
+++ b/listeners.js
@@ -1,5 +1,4 @@
 import { MODE_STOP } from "./constants.js";
-import { getSelectedAllergenToken, getStopButtonMode } from "./state.js";
 
 const DomEventName = {
     CLICK: "click",
@@ -17,19 +16,23 @@ const AriaHiddenValue = {
 };
 
 const ListenerErrorMessage = {
-    MISSING_DEPENDENCIES: "createListenerBinder requires controlElementId and attributeName"
+    MISSING_DEPENDENCIES: "createListenerBinder requires controlElementId, attributeName, and stateManager",
+    MISSING_STATE_MANAGER_METHODS: "createListenerBinder requires stateManager methods hasSelectedAllergen and getStopButtonMode"
 };
 
-function createListenerBinder({ controlElementId, attributeName, documentReference = document }) {
-    if (!controlElementId || !attributeName) {
+function createListenerBinder({ controlElementId, attributeName, documentReference = document, stateManager }) {
+    if (!controlElementId || !attributeName || !stateManager) {
         throw new Error(ListenerErrorMessage.MISSING_DEPENDENCIES);
+    }
+    if (typeof stateManager.hasSelectedAllergen !== "function" || typeof stateManager.getStopButtonMode !== "function") {
+        throw new Error(ListenerErrorMessage.MISSING_STATE_MANAGER_METHODS);
     }
 
     function wireStartButton({ onStartRequested }) {
         const startButton = documentReference.getElementById(controlElementId.START_BUTTON);
         if (!startButton) return;
         startButton.addEventListener(DomEventName.CLICK, () => {
-            if (!getSelectedAllergenToken()) return;
+            if (!stateManager.hasSelectedAllergen()) return;
             if (typeof onStartRequested === "function") {
                 onStartRequested();
             }
@@ -40,7 +43,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
         const stopButton = documentReference.getElementById(controlElementId.STOP_BUTTON);
         if (!stopButton) return;
         stopButton.addEventListener(DomEventName.CLICK, () => {
-            if (getStopButtonMode() === MODE_STOP) {
+            if (stateManager.getStopButtonMode() === MODE_STOP) {
                 if (typeof onStopRequested === "function") onStopRequested();
             } else if (typeof onShowAllergyScreen === "function") {
                 onShowAllergyScreen();

--- a/state.js
+++ b/state.js
@@ -2,125 +2,126 @@ import { MODE_STOP, MODE_START } from "./constants.js";
 
 const DEFAULT_INITIAL_HEARTS_COUNT = 5;
 
-const gameState = {
-    board: null,
-    initialHeartsCount: DEFAULT_INITIAL_HEARTS_COUNT,
-    heartsCount: DEFAULT_INITIAL_HEARTS_COUNT,
-    selectedAllergenToken: null,
-    selectedAllergenLabel: "",
-    wheelCandidateDishes: [],
-    wheelCandidateLabels: [],
-    stopButtonMode: MODE_STOP
-};
+const TextValue = Object.freeze({
+    EMPTY: ""
+});
 
-function initializeState({ initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT, initialStopButtonMode = MODE_STOP } = {}) {
-    if (typeof initialHeartsCount !== "number" || Number.isNaN(initialHeartsCount)) {
-        throw new Error("initializeState requires a numeric initialHeartsCount");
+const StateManagerErrorMessage = Object.freeze({
+    INVALID_INITIAL_HEARTS_COUNT: "StateManager.initialize requires a numeric initialHeartsCount",
+    INVALID_HEARTS_COUNT: "StateManager.setHeartsCount requires a numeric value"
+});
+
+class StateManager {
+    #board;
+
+    #initialHeartsCount;
+
+    #heartsCount;
+
+    #selectedAllergenToken;
+
+    #selectedAllergenLabel;
+
+    #wheelCandidateDishes;
+
+    #wheelCandidateLabels;
+
+    #stopButtonMode;
+
+    constructor({ initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT, initialStopButtonMode = MODE_STOP } = {}) {
+        this.initialize({ initialHeartsCount, initialStopButtonMode });
     }
-    gameState.initialHeartsCount = initialHeartsCount;
-    gameState.heartsCount = initialHeartsCount;
-    gameState.stopButtonMode = initialStopButtonMode === MODE_START ? MODE_START : MODE_STOP;
-    gameState.selectedAllergenToken = null;
-    gameState.selectedAllergenLabel = "";
-    gameState.wheelCandidateDishes = [];
-    gameState.wheelCandidateLabels = [];
-    gameState.board = null;
-}
 
-function setBoard(boardInstance) {
-    gameState.board = boardInstance || null;
-}
-
-function getBoard() {
-    return gameState.board;
-}
-
-function setSelectedAllergen({ token, label }) {
-    gameState.selectedAllergenToken = token || null;
-    gameState.selectedAllergenLabel = label || "";
-}
-
-function clearSelectedAllergen() {
-    gameState.selectedAllergenToken = null;
-    gameState.selectedAllergenLabel = "";
-}
-
-function getSelectedAllergenToken() {
-    return gameState.selectedAllergenToken;
-}
-
-function getSelectedAllergenLabel() {
-    return gameState.selectedAllergenLabel;
-}
-
-function hasSelectedAllergen() {
-    return Boolean(gameState.selectedAllergenToken);
-}
-
-function setWheelCandidates({ dishes = [], labels = [] }) {
-    gameState.wheelCandidateDishes = Array.isArray(dishes) ? dishes.slice() : [];
-    gameState.wheelCandidateLabels = Array.isArray(labels) ? labels.slice() : [];
-}
-
-function resetWheelCandidates() {
-    gameState.wheelCandidateDishes = [];
-    gameState.wheelCandidateLabels = [];
-}
-
-function getWheelCandidateDishes() {
-    return gameState.wheelCandidateDishes.slice();
-}
-
-function getWheelCandidateLabels() {
-    return gameState.wheelCandidateLabels.slice();
-}
-
-function setHeartsCount(newHeartsCount) {
-    if (typeof newHeartsCount !== "number" || Number.isNaN(newHeartsCount)) {
-        throw new Error("setHeartsCount requires a numeric value");
+    initialize({ initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT, initialStopButtonMode = MODE_STOP } = {}) {
+        if (typeof initialHeartsCount !== "number" || Number.isNaN(initialHeartsCount)) {
+            throw new Error(StateManagerErrorMessage.INVALID_INITIAL_HEARTS_COUNT);
+        }
+        this.#initialHeartsCount = initialHeartsCount;
+        this.#heartsCount = initialHeartsCount;
+        this.#stopButtonMode = initialStopButtonMode === MODE_START ? MODE_START : MODE_STOP;
+        this.#selectedAllergenToken = null;
+        this.#selectedAllergenLabel = TextValue.EMPTY;
+        this.#wheelCandidateDishes = [];
+        this.#wheelCandidateLabels = [];
+        this.#board = null;
     }
-    gameState.heartsCount = Math.max(0, Math.floor(newHeartsCount));
+
+    setBoard(boardInstance) {
+        this.#board = boardInstance || null;
+    }
+
+    getBoard() {
+        return this.#board;
+    }
+
+    setSelectedAllergen({ token, label } = {}) {
+        this.#selectedAllergenToken = token || null;
+        this.#selectedAllergenLabel = label || TextValue.EMPTY;
+    }
+
+    clearSelectedAllergen() {
+        this.#selectedAllergenToken = null;
+        this.#selectedAllergenLabel = TextValue.EMPTY;
+    }
+
+    getSelectedAllergenToken() {
+        return this.#selectedAllergenToken;
+    }
+
+    getSelectedAllergenLabel() {
+        return this.#selectedAllergenLabel;
+    }
+
+    hasSelectedAllergen() {
+        return Boolean(this.#selectedAllergenToken);
+    }
+
+    setWheelCandidates({ dishes = [], labels = [] } = {}) {
+        this.#wheelCandidateDishes = Array.isArray(dishes) ? dishes.slice() : [];
+        this.#wheelCandidateLabels = Array.isArray(labels) ? labels.slice() : [];
+    }
+
+    resetWheelCandidates() {
+        this.#wheelCandidateDishes = [];
+        this.#wheelCandidateLabels = [];
+    }
+
+    getWheelCandidateDishes() {
+        return this.#wheelCandidateDishes.slice();
+    }
+
+    getWheelCandidateLabels() {
+        return this.#wheelCandidateLabels.slice();
+    }
+
+    setHeartsCount(newHeartsCount) {
+        if (typeof newHeartsCount !== "number" || Number.isNaN(newHeartsCount)) {
+            throw new Error(StateManagerErrorMessage.INVALID_HEARTS_COUNT);
+        }
+        this.#heartsCount = Math.max(0, Math.floor(newHeartsCount));
+    }
+
+    incrementHeartsCount() {
+        this.#heartsCount += 1;
+        return this.#heartsCount;
+    }
+
+    decrementHeartsCount() {
+        this.#heartsCount = Math.max(0, this.#heartsCount - 1);
+        return this.#heartsCount;
+    }
+
+    getInitialHeartsCount() {
+        return this.#initialHeartsCount;
+    }
+
+    setStopButtonMode(mode) {
+        this.#stopButtonMode = mode === MODE_START ? MODE_START : MODE_STOP;
+    }
+
+    getStopButtonMode() {
+        return this.#stopButtonMode;
+    }
 }
 
-function incrementHeartsCount() {
-    gameState.heartsCount += 1;
-    return gameState.heartsCount;
-}
-
-function decrementHeartsCount() {
-    gameState.heartsCount = Math.max(0, gameState.heartsCount - 1);
-    return gameState.heartsCount;
-}
-
-function getInitialHeartsCount() {
-    return gameState.initialHeartsCount;
-}
-
-function setStopButtonMode(mode) {
-    gameState.stopButtonMode = mode === MODE_START ? MODE_START : MODE_STOP;
-}
-
-function getStopButtonMode() {
-    return gameState.stopButtonMode;
-}
-
-export {
-    initializeState,
-    setBoard,
-    getBoard,
-    setSelectedAllergen,
-    clearSelectedAllergen,
-    getSelectedAllergenToken,
-    getSelectedAllergenLabel,
-    hasSelectedAllergen,
-    setWheelCandidates,
-    resetWheelCandidates,
-    getWheelCandidateDishes,
-    getWheelCandidateLabels,
-    setHeartsCount,
-    incrementHeartsCount,
-    decrementHeartsCount,
-    getInitialHeartsCount,
-    setStopButtonMode,
-    getStopButtonMode
-};
+export { StateManager, DEFAULT_INITIAL_HEARTS_COUNT };


### PR DESCRIPTION
## Summary
- replace the state module’s exported functions with a `StateManager` class that encapsulates game state and validation
- inject the shared `StateManager` instance into the listener binder instead of importing module-level helpers
- create and initialize the shared `StateManager` in `app.js`, passing it to dependent components

## Testing
- npm test *(fails: no package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ed0d1bf4832797457de54e58b2d4