### PR TITLE
Refactor wheel rendering and interface

### DIFF
--- a/game.js
+++ b/game.js
@@ -376,8 +376,8 @@ export class GameController {
         if (typeof wireStopButton === "function") {
             wireStopButton({
                 onStopRequested: () => {
-                    if (this.#wheel.forceStop) {
-                        this.#wheel.forceStop();
+                    if (this.#wheel.stop) {
+                        this.#wheel.stop();
                     }
                 },
                 onShowAllergyScreen: () => {
@@ -465,8 +465,8 @@ export class GameController {
 
         this.#applyStopMode();
         const randomIndex = generateRandomIntegerInclusive(0, candidateLabels.length - 1);
-        if (this.#wheel.spinToIndex) {
-            this.#wheel.spinToIndex(randomIndex);
+        if (this.#wheel.spin) {
+            this.#wheel.spin(randomIndex);
         }
     }
 


### PR DESCRIPTION
## Summary
- rename wheel layout fields to descriptive names and break drawing into focused helper methods
- expose spin and stop methods while extracting reusable animation helpers for clarity
- update the game controller to use the refined wheel interface

## Testing
- npm test *(fails: no package.json available)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ef02dc348327acc3beb63d8d8fd8