### PR TITLE
refactor: centralize shared constants

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,33 +5,17 @@ import { StateManager } from "./state.js";
 import { Board } from "./board.js";
 import { NormalizationEngine, loadJson, pickRandomUnique } from "./utils.js";
 import { AllergenCard } from "./firstCard.js";
-import { ResultCard, ElementId as ResultCardElementId } from "./lastCard.js";
+import { ResultCard } from "./lastCard.js";
 import { renderHearts, animateHeartGainFromReveal, animateHeartLossAtHeartsBar } from "./hearts.js";
 import { primeAudioOnFirstGesture, playTick, playSiren, playNomNom, playWin } from "./audio.js";
 import { showScreen, setWheelControlToStop, setWheelControlToStartGame } from "./ui.js";
-
-const ControlElementId = Object.freeze({
-    START_BUTTON: "start",
-    STOP_BUTTON: "stop",
-    FULLSCREEN_BUTTON: "fs",
-    SPIN_AGAIN_BUTTON: "again",
-    REVEAL_SECTION: "reveal",
-    GAME_OVER_SECTION: "gameover",
-    RESTART_BUTTON: "restart"
-});
-
-const AttributeName = Object.freeze({
-    ARIA_HIDDEN: "aria-hidden"
-});
-
-const BrowserEventName = Object.freeze({
-    DOM_CONTENT_LOADED: "DOMContentLoaded"
-});
-
-const FirstCardElementId = Object.freeze({
-    LIST_CONTAINER: "allergy-list",
-    BADGE_CONTAINER: "sel-badges"
-});
+import {
+    ControlElementId,
+    AttributeName,
+    BrowserEventName,
+    FirstCardElementId,
+    ResultCardElementId
+} from "./constants.js";
 
 const stateManager = new StateManager();
 

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,84 @@
 /* File: constants.js */
-export const SCREEN_ALLERGY = "allergy";
-export const SCREEN_WHEEL = "wheel";
 
-export const MODE_STOP = "stop";
-export const MODE_START = "start";
+export const ScreenName = Object.freeze({
+    ALLERGY: "allergy",
+    WHEEL: "wheel"
+});
+
+export const SCREEN_ALLERGY = ScreenName.ALLERGY;
+export const SCREEN_WHEEL = ScreenName.WHEEL;
+
+export const WheelControlMode = Object.freeze({
+    STOP: "stop",
+    START: "start"
+});
+
+export const MODE_STOP = WheelControlMode.STOP;
+export const MODE_START = WheelControlMode.START;
+
+export const ControlElementId = Object.freeze({
+    START_BUTTON: "start",
+    STOP_BUTTON: "stop",
+    FULLSCREEN_BUTTON: "fs",
+    SPIN_AGAIN_BUTTON: "again",
+    REVEAL_SECTION: "reveal",
+    GAME_OVER_SECTION: "gameover",
+    RESTART_BUTTON: "restart"
+});
+
+export const FirstCardElementId = Object.freeze({
+    LIST_CONTAINER: "allergy-list",
+    BADGE_CONTAINER: "sel-badges"
+});
+
+export const ResultCardElementId = Object.freeze({
+    REVEAL_SECTION: ControlElementId.REVEAL_SECTION,
+    DISH_TITLE: "dish-title",
+    DISH_CUISINE: "dish-cuisine",
+    RESULT_BANNER: "result",
+    RESULT_TEXT: "result-text",
+    INGREDIENTS_CONTAINER: "dish-ingredients",
+    FACE_SVG: "face",
+    GAME_OVER_SECTION: ControlElementId.GAME_OVER_SECTION,
+    WIN_RESTART_BUTTON: "win-restart"
+});
+
+export const DocumentElementId = Object.freeze({
+    LOADING: "loading",
+    LOAD_ERROR: "load-error",
+    WHEEL_CANVAS: "wheel"
+});
+
+export const HeartsElementId = Object.freeze({
+    HEARTS_BAR: "hearts-bar"
+});
+
+export const AttributeName = Object.freeze({
+    ARIA_HIDDEN: "aria-hidden",
+    DATA_SCREEN: "data-screen",
+    DATA_COUNT: "data-count",
+    ARIA_LABEL: "aria-label"
+});
+
+export const AttributeBooleanValue = Object.freeze({
+    TRUE: "true",
+    FALSE: "false"
+});
+
+export const BrowserEventName = Object.freeze({
+    DOM_CONTENT_LOADED: "DOMContentLoaded",
+    CLICK: "click",
+    KEY_DOWN: "keydown",
+    CHANGE: "change"
+});
+
+export const KeyboardKey = Object.freeze({
+    ESCAPE: "Escape",
+    ESC: "Esc"
+});
+
+export const ButtonText = Object.freeze({
+    START: "Start",
+    STOP: "STOP",
+    RESTART: "Restart"
+});

--- a/firstCard.js
+++ b/firstCard.js
@@ -1,4 +1,5 @@
 /* global document */
+import { BrowserEventName } from "./constants.js";
 
 const ElementClassName = Object.freeze({
     CHIP: "chip",
@@ -20,10 +21,6 @@ const ElementTagName = Object.freeze({
 const TextContent = Object.freeze({
     EMPTY: "",
     SPACE_PREFIX: " "
-});
-
-const EventName = Object.freeze({
-    CHANGE: "change"
 });
 
 const ValueType = Object.freeze({
@@ -71,7 +68,7 @@ export class AllergenCard {
             radioElement.name = RadioInputConfiguration.NAME;
             radioElement.value = allergenToken;
 
-            radioElement.addEventListener(EventName.CHANGE, () => {
+            radioElement.addEventListener(BrowserEventName.CHANGE, () => {
                 this.#handleAllergenSelection({
                     token: allergenToken,
                     label: allergenLabel,

--- a/game.js
+++ b/game.js
@@ -1,3 +1,13 @@
+import {
+    ButtonText,
+    ScreenName,
+    MODE_START,
+    MODE_STOP,
+    BrowserEventName,
+    AttributeBooleanValue,
+    DocumentElementId
+} from "./constants.js";
+
 const WheelConfiguration = Object.freeze({
     SEGMENT_COUNT: 8,
     DEFAULT_SPIN_DURATION_MS: 30000,
@@ -21,21 +31,6 @@ const ButtonClassName = Object.freeze({
     DANGER: "danger"
 });
 
-const ButtonText = Object.freeze({
-    START: "Start",
-    STOP: "STOP"
-});
-
-const ScreenName = Object.freeze({
-    ALLERGY: "allergy",
-    WHEEL: "wheel"
-});
-
-const ButtonMode = Object.freeze({
-    START: "start",
-    STOP: "stop"
-});
-
 const GameErrorMessage = Object.freeze({
     MISSING_DEPENDENCIES: "GameController requires wheel, board, listenerBinder, stateManager, uiPresenter, firstCardPresenter, revealCardPresenter, heartsPresenter, audioPresenter, dataLoader, createNormalizationEngine, and pickRandomUnique.",
     INVALID_DATA_LOADER: "GameController requires dataLoader.loadJson to be a function.",
@@ -52,25 +47,11 @@ const DataPath = Object.freeze({
     INGREDIENTS: "./data/ingredients.json"
 });
 
-const DocumentElementId = Object.freeze({
-    LOADING: "loading",
-    LOAD_ERROR: "load-error",
-    WHEEL_CANVAS: "wheel"
-});
-
-const BrowserEventName = Object.freeze({
-    CLICK: "click"
-});
-
 const DataValidationMessage = Object.freeze({
     ALLERGENS: "allergens.json is missing or empty",
     DISHES: "dishes.json is missing or empty",
     NORMALIZATION: "normalization.json is missing or empty",
     INGREDIENTS: "ingredients.json is missing or empty"
-});
-
-const BooleanAttributeValue = Object.freeze({
-    TRUE: "true"
 });
 
 function generateRandomIntegerInclusive(minInclusive, maxInclusive) {
@@ -604,7 +585,7 @@ export class GameController {
                     if (revealSection) {
                         revealSection.setAttribute(
                             this.#attributeNameMap.ARIA_HIDDEN,
-                            BooleanAttributeValue.TRUE
+                            AttributeBooleanValue.TRUE
                         );
                     }
                     this.#resetGame();
@@ -650,7 +631,7 @@ export class GameController {
         const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
         if (!centerButton) {
             if (this.#stateManager.setStopButtonMode) {
-                this.#stateManager.setStopButtonMode(ButtonMode.START);
+                this.#stateManager.setStopButtonMode(MODE_START);
             }
             if (this.#uiPresenter.setWheelControlToStartGame) {
                 this.#uiPresenter.setWheelControlToStartGame();
@@ -661,7 +642,7 @@ export class GameController {
         centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.START);
         centerButton.classList.remove(ButtonClassName.STOP, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
         if (this.#stateManager.setStopButtonMode) {
-            this.#stateManager.setStopButtonMode(ButtonMode.START);
+            this.#stateManager.setStopButtonMode(MODE_START);
         }
         if (this.#uiPresenter.setWheelControlToStartGame) {
             this.#uiPresenter.setWheelControlToStartGame();
@@ -672,7 +653,7 @@ export class GameController {
         const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
         if (!centerButton) {
             if (this.#stateManager.setStopButtonMode) {
-                this.#stateManager.setStopButtonMode(ButtonMode.STOP);
+                this.#stateManager.setStopButtonMode(MODE_STOP);
             }
             if (this.#uiPresenter.setWheelControlToStop) {
                 this.#uiPresenter.setWheelControlToStop();
@@ -683,7 +664,7 @@ export class GameController {
         centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.STOP);
         centerButton.classList.remove(ButtonClassName.START, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
         if (this.#stateManager.setStopButtonMode) {
-            this.#stateManager.setStopButtonMode(ButtonMode.STOP);
+            this.#stateManager.setStopButtonMode(MODE_STOP);
         }
         if (this.#uiPresenter.setWheelControlToStop) {
             this.#uiPresenter.setWheelControlToStop();

--- a/hearts.js
+++ b/hearts.js
@@ -1,18 +1,5 @@
 /* global document */
-
-const ElementId = Object.freeze({
-    HEARTS_BAR: "hearts-bar"
-});
-
-const AttributeName = Object.freeze({
-    DATA_COUNT: "data-count",
-    ARIA_LABEL: "aria-label",
-    ARIA_HIDDEN: "aria-hidden"
-});
-
-const AttributeValue = Object.freeze({
-    TRUE: "true"
-});
+import { AttributeName, AttributeBooleanValue, HeartsElementId } from "./constants.js";
 
 const ElementTagName = Object.freeze({
     SPAN: "span"
@@ -50,7 +37,7 @@ function appendHeartElements(heartsBarElement, totalHearts) {
     for (let heartIndex = 0; heartIndex < totalHearts; heartIndex += 1) {
         const heartElement = document.createElement(ElementTagName.SPAN);
         heartElement.className = HeartClassName.HEART;
-        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
         heartElement.textContent = HeartSymbol;
         heartsBarElement.appendChild(heartElement);
     }
@@ -60,7 +47,7 @@ function appendGainHearts(heartsBarElement, heartsToAdd) {
     for (let heartGainIndex = 0; heartGainIndex < heartsToAdd; heartGainIndex += 1) {
         const heartElement = document.createElement(ElementTagName.SPAN);
         heartElement.className = HeartClassName.HEART_GAIN;
-        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+        heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
         heartElement.textContent = HeartSymbol;
         heartsBarElement.appendChild(heartElement);
     }
@@ -78,7 +65,7 @@ function removeHeartElements(heartsBarElement, heartsToRemove) {
 
 export function renderHearts(count, options = {}) {
     const { animate = false } = options;
-    const heartsBarElement = document.getElementById(ElementId.HEARTS_BAR);
+    const heartsBarElement = document.getElementById(HeartsElementId.HEARTS_BAR);
     if (!heartsBarElement) {
         return;
     }

--- a/lastCard.js
+++ b/lastCard.js
@@ -1,16 +1,10 @@
 /* global document */
-
-export const ElementId = Object.freeze({
-    REVEAL_SECTION: "reveal",
-    DISH_TITLE: "dish-title",
-    DISH_CUISINE: "dish-cuisine",
-    RESULT_BANNER: "result",
-    RESULT_TEXT: "result-text",
-    INGREDIENTS_CONTAINER: "dish-ingredients",
-    FACE_SVG: "face",
-    GAME_OVER_SECTION: "gameover",
-    WIN_RESTART_BUTTON: "win-restart"
-});
+import {
+    ResultCardElementId,
+    AttributeName,
+    AttributeBooleanValue,
+    ButtonText
+} from "./constants.js";
 
 const ElementTagName = Object.freeze({
     SPAN: "span",
@@ -29,20 +23,11 @@ const Selector = Object.freeze({
     ACTIONS_CONTAINER: ".actions"
 });
 
-const AttributeName = Object.freeze({
-    ARIA_HIDDEN: "aria-hidden"
-});
-
-const AttributeValue = Object.freeze({
-    FALSE: "false"
-});
-
 const TextContent = Object.freeze({
     EMPTY: "",
     SPACE: " ",
     WIN_TITLE: "You Win! 🏆",
     WIN_MESSAGE: "Amazing! You collected 10 hearts!",
-    RESTART_BUTTON_LABEL: "Restart",
     SAFE_TO_EAT: "Safe to eat. Yummy!",
     RESULT_BAD_PREFIX: "Contains your allergen: "
 });
@@ -270,7 +255,7 @@ export class ResultCard {
         }
 
         if (this.#revealSectionElement) {
-            this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+            this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.FALSE);
         }
 
         return { hasTriggeringIngredient };
@@ -278,7 +263,7 @@ export class ResultCard {
 
     showGameOver() {
         if (this.#gameOverSectionElement) {
-            this.#gameOverSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+            this.#gameOverSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.FALSE);
             return { isDisplayed: true };
         }
         return { isDisplayed: false };
@@ -307,11 +292,11 @@ export class ResultCard {
         this.#actionsContainerElement.textContent = TextContent.EMPTY;
         const restartButton = this.#documentReference.createElement(ElementTagName.BUTTON);
         restartButton.className = ClassName.BUTTON_PRIMARY;
-        restartButton.id = ElementId.WIN_RESTART_BUTTON;
-        restartButton.textContent = TextContent.RESTART_BUTTON_LABEL;
+        restartButton.id = ResultCardElementId.WIN_RESTART_BUTTON;
+        restartButton.textContent = ButtonText.RESTART;
         this.#actionsContainerElement.appendChild(restartButton);
 
-        this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.FALSE);
+        this.#revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.FALSE);
         return { restartButton, isDisplayed: true };
     }
 

--- a/listeners.js
+++ b/listeners.js
@@ -1,19 +1,4 @@
-import { MODE_STOP } from "./constants.js";
-
-const DomEventName = {
-    CLICK: "click",
-    KEY_DOWN: "keydown"
-};
-
-const KeyboardKey = {
-    ESCAPE: "Escape",
-    ESC: "Esc"
-};
-
-const AriaHiddenValue = {
-    TRUE: "true",
-    FALSE: "false"
-};
+import { MODE_STOP, BrowserEventName, KeyboardKey, AttributeBooleanValue } from "./constants.js";
 
 const ListenerErrorMessage = {
     MISSING_DEPENDENCIES: "createListenerBinder requires controlElementId, attributeName, and stateManager",
@@ -31,7 +16,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireStartButton({ onStartRequested }) {
         const startButton = documentReference.getElementById(controlElementId.START_BUTTON);
         if (!startButton) return;
-        startButton.addEventListener(DomEventName.CLICK, () => {
+        startButton.addEventListener(BrowserEventName.CLICK, () => {
             if (!stateManager.hasSelectedAllergen()) return;
             if (typeof onStartRequested === "function") {
                 onStartRequested();
@@ -42,7 +27,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireStopButton({ onStopRequested, onShowAllergyScreen }) {
         const stopButton = documentReference.getElementById(controlElementId.STOP_BUTTON);
         if (!stopButton) return;
-        stopButton.addEventListener(DomEventName.CLICK, () => {
+        stopButton.addEventListener(BrowserEventName.CLICK, () => {
             if (stateManager.getStopButtonMode() === MODE_STOP) {
                 if (typeof onStopRequested === "function") onStopRequested();
             } else if (typeof onShowAllergyScreen === "function") {
@@ -54,7 +39,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireFullscreenButton() {
         const fullscreenButton = documentReference.getElementById(controlElementId.FULLSCREEN_BUTTON);
         if (!fullscreenButton) return;
-        fullscreenButton.addEventListener(DomEventName.CLICK, () => {
+        fullscreenButton.addEventListener(BrowserEventName.CLICK, () => {
             const rootElement = documentReference.documentElement;
             if (!documentReference.fullscreenElement) rootElement.requestFullscreen();
             else documentReference.exitFullscreen();
@@ -64,10 +49,10 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireSpinAgainButton({ onSpinAgain }) {
         const spinAgainButton = documentReference.getElementById(controlElementId.SPIN_AGAIN_BUTTON);
         if (!spinAgainButton) return;
-        spinAgainButton.addEventListener(DomEventName.CLICK, () => {
+        spinAgainButton.addEventListener(BrowserEventName.CLICK, () => {
             const revealSection = documentReference.getElementById(controlElementId.REVEAL_SECTION);
             if (revealSection) {
-                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AriaHiddenValue.TRUE);
+                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
             }
             if (typeof onSpinAgain === "function") onSpinAgain();
         });
@@ -76,16 +61,16 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireRevealBackdropDismissal() {
         const revealSection = documentReference.getElementById(controlElementId.REVEAL_SECTION);
         if (!revealSection) return;
-        revealSection.addEventListener(DomEventName.CLICK, (eventObject) => {
+        revealSection.addEventListener(BrowserEventName.CLICK, (eventObject) => {
             if (eventObject.target === revealSection) {
-                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AriaHiddenValue.TRUE);
+                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
             }
         });
-        documentReference.addEventListener(DomEventName.KEY_DOWN, (eventObject) => {
+        documentReference.addEventListener(BrowserEventName.KEY_DOWN, (eventObject) => {
             const isEscapeKey = eventObject.key === KeyboardKey.ESCAPE || eventObject.key === KeyboardKey.ESC;
-            const isRevealVisible = revealSection.getAttribute(attributeName.ARIA_HIDDEN) === AriaHiddenValue.FALSE;
+            const isRevealVisible = revealSection.getAttribute(attributeName.ARIA_HIDDEN) === AttributeBooleanValue.FALSE;
             if (isEscapeKey && isRevealVisible) {
-                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AriaHiddenValue.TRUE);
+                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
             }
         });
     }
@@ -93,14 +78,14 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireRestartButton({ onRestart }) {
         const restartButton = documentReference.getElementById(controlElementId.RESTART_BUTTON);
         if (!restartButton) return;
-        restartButton.addEventListener(DomEventName.CLICK, () => {
+        restartButton.addEventListener(BrowserEventName.CLICK, () => {
             const gameOverSection = documentReference.getElementById(controlElementId.GAME_OVER_SECTION);
             if (gameOverSection) {
-                gameOverSection.setAttribute(attributeName.ARIA_HIDDEN, AriaHiddenValue.TRUE);
+                gameOverSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
             }
             const revealSection = documentReference.getElementById(controlElementId.REVEAL_SECTION);
             if (revealSection) {
-                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AriaHiddenValue.TRUE);
+                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
             }
             if (typeof onRestart === "function") onRestart();
         });

--- a/ui.js
+++ b/ui.js
@@ -1,18 +1,11 @@
 /* global document */
-import { SCREEN_ALLERGY, SCREEN_WHEEL } from "./constants.js";
-
-const ElementId = Object.freeze({
-    REVEAL_SECTION: "reveal"
-});
-
-const AttributeName = Object.freeze({
-    DATA_SCREEN: "data-screen",
-    ARIA_HIDDEN: "aria-hidden"
-});
-
-const AttributeValue = Object.freeze({
-    TRUE: "true"
-});
+import {
+    SCREEN_ALLERGY,
+    SCREEN_WHEEL,
+    AttributeName,
+    AttributeBooleanValue,
+    ResultCardElementId
+} from "./constants.js";
 
 export function showScreen(screenName) {
     const bodyElement = document.body;
@@ -20,7 +13,7 @@ export function showScreen(screenName) {
         return;
     }
 
-    const revealElement = document.getElementById(ElementId.REVEAL_SECTION);
+    const revealElement = document.getElementById(ResultCardElementId.REVEAL_SECTION);
 
     if (screenName === SCREEN_ALLERGY) {
         bodyElement.setAttribute(AttributeName.DATA_SCREEN, SCREEN_ALLERGY);
@@ -29,7 +22,7 @@ export function showScreen(screenName) {
     }
 
     if (revealElement) {
-        revealElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeValue.TRUE);
+        revealElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
     }
 }
 


### PR DESCRIPTION
## Summary
- centralize screen identifiers, control element ids, attribute names, browser events, and button labels inside `constants.js`
- update application bootstrap, presenters, and listeners to consume the shared constants for ids, attributes, and button text
- use the shared browser event names when wiring first card selection and other controls to keep event naming consistent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8f4bb8588832782b5ea8d4e06a0a0