### PR TITLE
Normalize random integer range handling

### DIFF
--- a/game.js
+++ b/game.js
@@ -54,9 +54,18 @@ const DataValidationMessage = Object.freeze({
     INGREDIENTS: "ingredients.json is missing or empty"
 });
 
+/**
+ * Generates a random integer within the inclusive range defined by the provided bounds.
+ * If the lower bound exceeds the upper bound, the values are swapped before generating the result.
+ */
 function generateRandomIntegerInclusive(minInclusive, maxInclusive) {
-    const minimum = Math.ceil(minInclusive);
-    const maximum = Math.floor(maxInclusive);
+    const areBoundsInverted = minInclusive > maxInclusive;
+    const normalizedMinimumInput = areBoundsInverted ? maxInclusive : minInclusive;
+    const normalizedMaximumInput = areBoundsInverted ? minInclusive : maxInclusive;
+
+    const minimum = Math.ceil(normalizedMinimumInput);
+    const maximum = Math.floor(normalizedMaximumInput);
+
     return Math.floor(Math.random() * (maximum - minimum + 1)) + minimum;
 }
 


### PR DESCRIPTION
## Summary
- document the random integer helper and handle inverted range inputs by swapping the bounds before generating a value

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68c8fa08cd00832799cdbec775b409b9