### PR TITLE
Replace alias constants with canonical enums

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -5,16 +5,12 @@ export const ScreenName = Object.freeze({
     WHEEL: "wheel"
 });
 
-export const SCREEN_ALLERGY = ScreenName.ALLERGY;
-export const SCREEN_WHEEL = ScreenName.WHEEL;
 
 export const WheelControlMode = Object.freeze({
     STOP: "stop",
     START: "start"
 });
 
-export const MODE_STOP = WheelControlMode.STOP;
-export const MODE_START = WheelControlMode.START;
 
 export const ControlElementId = Object.freeze({
     START_BUTTON: "start",

--- a/game.js
+++ b/game.js
@@ -1,8 +1,7 @@
 import {
     ButtonText,
     ScreenName,
-    MODE_START,
-    MODE_STOP,
+    WheelControlMode,
     BrowserEventName,
     AttributeBooleanValue,
     DocumentElementId
@@ -631,7 +630,7 @@ export class GameController {
         const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
         if (!centerButton) {
             if (this.#stateManager.setStopButtonMode) {
-                this.#stateManager.setStopButtonMode(MODE_START);
+                this.#stateManager.setStopButtonMode(WheelControlMode.START);
             }
             if (this.#uiPresenter.setWheelControlToStartGame) {
                 this.#uiPresenter.setWheelControlToStartGame();
@@ -642,7 +641,7 @@ export class GameController {
         centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.START);
         centerButton.classList.remove(ButtonClassName.STOP, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
         if (this.#stateManager.setStopButtonMode) {
-            this.#stateManager.setStopButtonMode(MODE_START);
+            this.#stateManager.setStopButtonMode(WheelControlMode.START);
         }
         if (this.#uiPresenter.setWheelControlToStartGame) {
             this.#uiPresenter.setWheelControlToStartGame();
@@ -653,7 +652,7 @@ export class GameController {
         const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
         if (!centerButton) {
             if (this.#stateManager.setStopButtonMode) {
-                this.#stateManager.setStopButtonMode(MODE_STOP);
+                this.#stateManager.setStopButtonMode(WheelControlMode.STOP);
             }
             if (this.#uiPresenter.setWheelControlToStop) {
                 this.#uiPresenter.setWheelControlToStop();
@@ -664,7 +663,7 @@ export class GameController {
         centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.STOP);
         centerButton.classList.remove(ButtonClassName.START, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
         if (this.#stateManager.setStopButtonMode) {
-            this.#stateManager.setStopButtonMode(MODE_STOP);
+            this.#stateManager.setStopButtonMode(WheelControlMode.STOP);
         }
         if (this.#uiPresenter.setWheelControlToStop) {
             this.#uiPresenter.setWheelControlToStop();

--- a/listeners.js
+++ b/listeners.js
@@ -1,4 +1,4 @@
-import { MODE_STOP, BrowserEventName, KeyboardKey, AttributeBooleanValue } from "./constants.js";
+import { WheelControlMode, BrowserEventName, KeyboardKey, AttributeBooleanValue } from "./constants.js";
 
 const ListenerErrorMessage = {
     MISSING_DEPENDENCIES: "createListenerBinder requires controlElementId, attributeName, and stateManager",
@@ -28,7 +28,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
         const stopButton = documentReference.getElementById(controlElementId.STOP_BUTTON);
         if (!stopButton) return;
         stopButton.addEventListener(BrowserEventName.CLICK, () => {
-            if (stateManager.getStopButtonMode() === MODE_STOP) {
+            if (stateManager.getStopButtonMode() === WheelControlMode.STOP) {
                 if (typeof onStopRequested === "function") onStopRequested();
             } else if (typeof onShowAllergyScreen === "function") {
                 onShowAllergyScreen();

--- a/state.js
+++ b/state.js
@@ -1,4 +1,4 @@
-import { MODE_STOP, MODE_START } from "./constants.js";
+import { WheelControlMode } from "./constants.js";
 
 const DEFAULT_INITIAL_HEARTS_COUNT = 5;
 
@@ -28,17 +28,26 @@ class StateManager {
 
     #stopButtonMode;
 
-    constructor({ initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT, initialStopButtonMode = MODE_STOP } = {}) {
+    constructor({
+        initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT,
+        initialStopButtonMode = WheelControlMode.STOP
+    } = {}) {
         this.initialize({ initialHeartsCount, initialStopButtonMode });
     }
 
-    initialize({ initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT, initialStopButtonMode = MODE_STOP } = {}) {
+    initialize({
+        initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT,
+        initialStopButtonMode = WheelControlMode.STOP
+    } = {}) {
         if (typeof initialHeartsCount !== "number" || Number.isNaN(initialHeartsCount)) {
             throw new Error(StateManagerErrorMessage.INVALID_INITIAL_HEARTS_COUNT);
         }
         this.#initialHeartsCount = initialHeartsCount;
         this.#heartsCount = initialHeartsCount;
-        this.#stopButtonMode = initialStopButtonMode === MODE_START ? MODE_START : MODE_STOP;
+        this.#stopButtonMode =
+            initialStopButtonMode === WheelControlMode.START
+                ? WheelControlMode.START
+                : WheelControlMode.STOP;
         this.#selectedAllergenToken = null;
         this.#selectedAllergenLabel = TextValue.EMPTY;
         this.#wheelCandidateDishes = [];
@@ -116,7 +125,8 @@ class StateManager {
     }
 
     setStopButtonMode(mode) {
-        this.#stopButtonMode = mode === MODE_START ? MODE_START : MODE_STOP;
+        this.#stopButtonMode =
+            mode === WheelControlMode.START ? WheelControlMode.START : WheelControlMode.STOP;
     }
 
     getStopButtonMode() {

--- a/ui.js
+++ b/ui.js
@@ -1,7 +1,6 @@
 /* global document */
 import {
-    SCREEN_ALLERGY,
-    SCREEN_WHEEL,
+    ScreenName,
     AttributeName,
     AttributeBooleanValue,
     ResultCardElementId
@@ -15,10 +14,10 @@ export function showScreen(screenName) {
 
     const revealElement = document.getElementById(ResultCardElementId.REVEAL_SECTION);
 
-    if (screenName === SCREEN_ALLERGY) {
-        bodyElement.setAttribute(AttributeName.DATA_SCREEN, SCREEN_ALLERGY);
-    } else if (screenName === SCREEN_WHEEL) {
-        bodyElement.setAttribute(AttributeName.DATA_SCREEN, SCREEN_WHEEL);
+    if (screenName === ScreenName.ALLERGY) {
+        bodyElement.setAttribute(AttributeName.DATA_SCREEN, ScreenName.ALLERGY);
+    } else if (screenName === ScreenName.WHEEL) {
+        bodyElement.setAttribute(AttributeName.DATA_SCREEN, ScreenName.WHEEL);
     }
 
     if (revealElement) {


### PR DESCRIPTION
## Summary
- remove the redundant alias exports for screen names and wheel modes
- update state management, UI, listeners, and game controller logic to use the ScreenName and WheelControlMode enums directly

## Testing
- npm test *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f9e0287c8327ade35b4660488903