### PR TITLE
Add missing ingredient and cuisine metadata

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -1,23 +1,207 @@
 [
-  { "cuisine": "American",       "country": "United States", "flag": "🇺🇸" },
-  { "cuisine": "Argentinian",    "country": "Argentina",     "flag": "🇦🇷" },
-  { "cuisine": "Brazilian",      "country": "Brazil",        "flag": "🇧🇷" },
-  { "cuisine": "British",        "country": "United Kingdom","flag": "🇬🇧" },
-  { "cuisine": "Canadian",       "country": "Canada",        "flag": "🇨🇦" },
-  { "cuisine": "Chinese",        "country": "China",         "flag": "🇨🇳" },
-  { "cuisine": "French",         "country": "France",        "flag": "🇫🇷" },
-  { "cuisine": "German",         "country": "Germany",       "flag": "🇩🇪" },
-  { "cuisine": "Greek",          "country": "Greece",        "flag": "🇬🇷" },
-  { "cuisine": "Indian",         "country": "India",         "flag": "🇮🇳" },
-  { "cuisine": "Italian",        "country": "Italy",         "flag": "🇮🇹" },
-  { "cuisine": "Japanese",       "country": "Japan",         "flag": "🇯🇵" },
-  { "cuisine": "Korean",         "country": "South Korea",   "flag": "🇰🇷" },
-  { "cuisine": "Mexican",        "country": "Mexico",        "flag": "🇲🇽" },
-  { "cuisine": "Moroccan",       "country": "Morocco",       "flag": "🇲🇦" },
-  { "cuisine": "Russian",        "country": "Russia",        "flag": "🇷🇺" },
-  { "cuisine": "Spanish",        "country": "Spain",         "flag": "🇪🇸" },
-  { "cuisine": "Thai",           "country": "Thailand",      "flag": "🇹🇭" },
-  { "cuisine": "Turkish",        "country": "Türkiye",       "flag": "🇹🇷" },
-  { "cuisine": "Vietnamese",     "country": "Vietnam",       "flag": "🇻🇳" },
-  { "cuisine": "Levantine",  "country": "Lebanon",       "flag": "🇱🇧" }
+  {
+    "cuisine": "American",
+    "country": "United States",
+    "flag": "🇺🇸"
+  },
+  {
+    "cuisine": "Argentinian",
+    "country": "Argentina",
+    "flag": "🇦🇷"
+  },
+  {
+    "cuisine": "Brazilian",
+    "country": "Brazil",
+    "flag": "🇧🇷"
+  },
+  {
+    "cuisine": "British",
+    "country": "United Kingdom",
+    "flag": "🇬🇧"
+  },
+  {
+    "cuisine": "Canadian",
+    "country": "Canada",
+    "flag": "🇨🇦"
+  },
+  {
+    "cuisine": "Chinese",
+    "country": "China",
+    "flag": "🇨🇳"
+  },
+  {
+    "cuisine": "French",
+    "country": "France",
+    "flag": "🇫🇷"
+  },
+  {
+    "cuisine": "German",
+    "country": "Germany",
+    "flag": "🇩🇪"
+  },
+  {
+    "cuisine": "Greek",
+    "country": "Greece",
+    "flag": "🇬🇷"
+  },
+  {
+    "cuisine": "Indian",
+    "country": "India",
+    "flag": "🇮🇳"
+  },
+  {
+    "cuisine": "Italian",
+    "country": "Italy",
+    "flag": "🇮🇹"
+  },
+  {
+    "cuisine": "Japanese",
+    "country": "Japan",
+    "flag": "🇯🇵"
+  },
+  {
+    "cuisine": "Korean",
+    "country": "South Korea",
+    "flag": "🇰🇷"
+  },
+  {
+    "cuisine": "Mexican",
+    "country": "Mexico",
+    "flag": "🇲🇽"
+  },
+  {
+    "cuisine": "Moroccan",
+    "country": "Morocco",
+    "flag": "🇲🇦"
+  },
+  {
+    "cuisine": "Russian",
+    "country": "Russia",
+    "flag": "🇷🇺"
+  },
+  {
+    "cuisine": "Spanish",
+    "country": "Spain",
+    "flag": "🇪🇸"
+  },
+  {
+    "cuisine": "Thai",
+    "country": "Thailand",
+    "flag": "🇹🇭"
+  },
+  {
+    "cuisine": "Turkish",
+    "country": "Türkiye",
+    "flag": "🇹🇷"
+  },
+  {
+    "cuisine": "Vietnamese",
+    "country": "Vietnam",
+    "flag": "🇻🇳"
+  },
+  {
+    "cuisine": "Levantine",
+    "country": "Lebanon",
+    "flag": "🇱🇧"
+  },
+  {
+    "cuisine": "Belgian",
+    "country": "Belgium",
+    "flag": "🇧🇪"
+  },
+  {
+    "cuisine": "Breakfast",
+    "country": "Worldwide",
+    "flag": "🌍"
+  },
+  {
+    "cuisine": "Cajun",
+    "country": "Louisiana, USA",
+    "flag": "⚜️"
+  },
+  {
+    "cuisine": "Candy",
+    "country": "Sweet Treats",
+    "flag": "🍭"
+  },
+  {
+    "cuisine": "Caribbean",
+    "country": "Caribbean",
+    "flag": "🏝️"
+  },
+  {
+    "cuisine": "Chinese-American",
+    "country": "China & United States",
+    "flag": "🇨🇳🇺🇸"
+  },
+  {
+    "cuisine": "Deli",
+    "country": "Delicatessen",
+    "flag": "🥪"
+  },
+  {
+    "cuisine": "Dessert",
+    "country": "Dessert Classics",
+    "flag": "🍰"
+  },
+  {
+    "cuisine": "Diner",
+    "country": "American Diner",
+    "flag": "🍽️"
+  },
+  {
+    "cuisine": "Fusion",
+    "country": "Global Fusion",
+    "flag": "🌐"
+  },
+  {
+    "cuisine": "Indo-Chinese",
+    "country": "India & China",
+    "flag": "🇮🇳🇨🇳"
+  },
+  {
+    "cuisine": "Italian-American",
+    "country": "Italy & United States",
+    "flag": "🇮🇹🇺🇸"
+  },
+  {
+    "cuisine": "Korean-Japanese",
+    "country": "Korea & Japan",
+    "flag": "🇰🇷🇯🇵"
+  },
+  {
+    "cuisine": "Malaysian",
+    "country": "Malaysia",
+    "flag": "🇲🇾"
+  },
+  {
+    "cuisine": "Mediterranean",
+    "country": "Mediterranean Region",
+    "flag": "🌊"
+  },
+  {
+    "cuisine": "Middle Eastern",
+    "country": "Middle East",
+    "flag": "🕌"
+  },
+  {
+    "cuisine": "Portuguese",
+    "country": "Portugal",
+    "flag": "🇵🇹"
+  },
+  {
+    "cuisine": "Snack",
+    "country": "Snack Time",
+    "flag": "🥨"
+  },
+  {
+    "cuisine": "Sri Lankan",
+    "country": "Sri Lanka",
+    "flag": "🇱🇰"
+  },
+  {
+    "cuisine": "Taiwanese",
+    "country": "Taiwan",
+    "flag": "🇹🇼"
+  }
 ]

--- a/data/ingredients.json
+++ b/data/ingredients.json
@@ -1,97 +1,717 @@
 [
-  { "name": "peanuts", "allergen": "peanuts", "emoji": "🥜" },
-  { "name": "peanut butter", "allergen": "peanuts", "emoji": "🥜" },
-  { "name": "peanut sauce", "allergen": "peanuts", "emoji": "🥜" },
-
-  { "name": "almonds", "allergen": "tree_nuts", "emoji": "🌰" },
-  { "name": "walnuts", "allergen": "tree_nuts", "emoji": "🌰" },
-  { "name": "hazelnuts", "allergen": "tree_nuts", "emoji": "🌰" },
-  { "name": "pistachios", "allergen": "tree_nuts", "emoji": "🌰" },
-  { "name": "pine nuts", "allergen": "tree_nuts", "emoji": "🌲" },
-  { "name": "cashews", "allergen": "tree_nuts", "emoji": "🥜" },
-
-  { "name": "sesame", "allergen": "sesame", "emoji": "⚪️" },
-  { "name": "tahini", "allergen": "sesame", "emoji": "🧴" },
-  { "name": "sesame oil", "allergen": "sesame", "emoji": "🧴" },
-
-  { "name": "shrimp", "allergen": "shellfish", "emoji": "🦐" },
-  { "name": "crab", "allergen": "shellfish", "emoji": "🦀" },
-  { "name": "lobster", "allergen": "shellfish", "emoji": "🦞" },
-  { "name": "mussels", "allergen": "shellfish", "emoji": "🦪" },
-  { "name": "oysters", "allergen": "shellfish", "emoji": "🦪" },
-  { "name": "squid (shellfish)", "allergen": "shellfish", "emoji": "🦑" },
-
-  { "name": "fish", "allergen": "fish", "emoji": "🐟" },
-  { "name": "salmon", "allergen": "fish", "emoji": "🐟" },
-  { "name": "cod", "allergen": "fish", "emoji": "🐟" },
-  { "name": "tuna", "allergen": "fish", "emoji": "🐟" },
-  { "name": "mackerel", "allergen": "fish", "emoji": "🐟" },
-
-  { "name": "milk", "allergen": "milk", "emoji": "🥛" },
-  { "name": "cream", "allergen": "milk", "emoji": "🥛" },
-  { "name": "butter", "allergen": "milk", "emoji": "🧈" },
-  { "name": "yogurt", "allergen": "milk", "emoji": "🥛" },
-  { "name": "mozzarella", "allergen": "milk", "emoji": "🧀" },
-  { "name": "parmesan", "allergen": "milk", "emoji": "🧀" },
-  { "name": "cheese", "allergen": "milk", "emoji": "🧀" },
-  { "name": "cream cheese", "allergen": "milk", "emoji": "🧀" },
-
-  { "name": "egg", "allergen": "egg", "emoji": "🥚" },
-
-  { "name": "soy sauce", "allergen": "soy", "emoji": "🫘" },
-  { "name": "tofu", "allergen": "soy", "emoji": "🫘" },
-
-  { "name": "wheat", "allergen": "wheat", "emoji": "🌾" },
-  { "name": "wheat dough", "allergen": "wheat", "emoji": "🌾" },
-  { "name": "wheat flour", "allergen": "wheat", "emoji": "🌾" },
-  { "name": "wheat pasta", "allergen": "wheat", "emoji": "🍝" },
-  { "name": "wheat spaghetti", "allergen": "wheat", "emoji": "🍝" },
-  { "name": "wheat penne", "allergen": "wheat", "emoji": "🍝" },
-  { "name": "wheat macaroni", "allergen": "wheat", "emoji": "🍝" },
-  { "name": "wheat ramen", "allergen": "wheat", "emoji": "🍜" },
-  { "name": "udon wheat noodles", "allergen": "wheat", "emoji": "🍜" },
-  { "name": "wheat soba", "allergen": "wheat", "emoji": "🍜" },
-  { "name": "wheat panko", "allergen": "wheat", "emoji": "🥯" },
-  { "name": "wheat bread", "allergen": "wheat", "emoji": "🍞" },
-  { "name": "wheat bun", "allergen": "wheat", "emoji": "🍞" },
-  { "name": "wheat tortillas", "allergen": "wheat", "emoji": "🌯" },
-  { "name": "wheat pita", "allergen": "wheat", "emoji": "🫓" },
-  { "name": "wheat wonton wrappers", "allergen": "wheat", "emoji": "🥟" },
-  { "name": "wheat berries", "allergen": "wheat", "emoji": "🌾" },
-  { "name": "wheat crumbs", "allergen": "wheat", "emoji": "🍞" },
-  { "name": "wheat starch", "allergen": "wheat", "emoji": "🌾" },
-
-  { "name": "italian sausage", "allergen": "italian_sausage", "emoji": "🌭" },
-
-  { "name": "nori", "allergen": "", "emoji": "🍘" },
-  { "name": "rice", "allergen": "", "emoji": "🍚" },
-  { "name": "pita bread", "allergen": "wheat", "emoji": "🫓" },
-  { "name": "tomato", "allergen": "", "emoji": "🍅" },
-  { "name": "basil", "allergen": "", "emoji": "🌿" },
-  { "name": "olive oil", "allergen": "", "emoji": "🫒" },
-  { "name": "mayonnaise", "allergen": "", "emoji": "🧴" },
-  { "name": "avocado", "allergen": "", "emoji": "🥑" },
-  { "name": "chicken", "allergen": "", "emoji": "🍗" },
-  { "name": "beef", "allergen": "", "emoji": "🥩" },
-  { "name": "pork", "allergen": "", "emoji": "🥩" },
-  { "name": "garlic", "allergen": "", "emoji": "🧄" },
-  { "name": "onion", "allergen": "", "emoji": "🧅" },
-  { "name": "cucumber", "allergen": "", "emoji": "🥒" },
-  { "name": "eggplant", "allergen": "", "emoji": "🍆" },
-  { "name": "potato", "allergen": "", "emoji": "🥔" },
-  { "name": "carrot", "allergen": "", "emoji": "🥕" },
-  { "name": "scallions", "allergen": "", "emoji": "🧅" },
-  { "name": "lime", "allergen": "", "emoji": "🍋" },
-  { "name": "lemon", "allergen": "", "emoji": "🍋" },
-  { "name": "cheddar",           "allergen": "milk",        "emoji": "🧀" },
-  { "name": "clams",             "allergen": "shellfish",   "emoji": "🦪" },
-  { "name": "fish sauce",        "allergen": "fish",        "emoji": "🐟" },
-  { "name": "wheat noodles",     "allergen": "wheat",       "emoji": "🍜" },
-  { "name": "crema",             "allergen": "milk",        "emoji": "🥛" },
-  { "name": "ricotta",           "allergen": "milk",        "emoji": "🧀" },
-  { "name": "tzatziki",          "allergen": "milk",        "emoji": "🥛" },
-  { "name": "corn tortillas",    "allergen": "",            "emoji": "🌮" },
-  { "name": "bread crumbs",      "allergen": "wheat",       "emoji": "🍞" },
-  { "name": "rice noodles",      "allergen": "",            "emoji": "🍜" }
+  {
+    "name": "peanuts",
+    "allergen": "peanuts",
+    "emoji": "🥜"
+  },
+  {
+    "name": "peanut butter",
+    "allergen": "peanuts",
+    "emoji": "🥜"
+  },
+  {
+    "name": "peanut sauce",
+    "allergen": "peanuts",
+    "emoji": "🥜"
+  },
+  {
+    "name": "almonds",
+    "allergen": "tree_nuts",
+    "emoji": "🌰"
+  },
+  {
+    "name": "walnuts",
+    "allergen": "tree_nuts",
+    "emoji": "🌰"
+  },
+  {
+    "name": "hazelnuts",
+    "allergen": "tree_nuts",
+    "emoji": "🌰"
+  },
+  {
+    "name": "pistachios",
+    "allergen": "tree_nuts",
+    "emoji": "🌰"
+  },
+  {
+    "name": "pine nuts",
+    "allergen": "tree_nuts",
+    "emoji": "🌲"
+  },
+  {
+    "name": "cashews",
+    "allergen": "tree_nuts",
+    "emoji": "🥜"
+  },
+  {
+    "name": "sesame",
+    "allergen": "sesame",
+    "emoji": "⚪️"
+  },
+  {
+    "name": "tahini",
+    "allergen": "sesame",
+    "emoji": "🧴"
+  },
+  {
+    "name": "sesame oil",
+    "allergen": "sesame",
+    "emoji": "🧴"
+  },
+  {
+    "name": "shrimp",
+    "allergen": "shellfish",
+    "emoji": "🦐"
+  },
+  {
+    "name": "crab",
+    "allergen": "shellfish",
+    "emoji": "🦀"
+  },
+  {
+    "name": "lobster",
+    "allergen": "shellfish",
+    "emoji": "🦞"
+  },
+  {
+    "name": "mussels",
+    "allergen": "shellfish",
+    "emoji": "🦪"
+  },
+  {
+    "name": "oysters",
+    "allergen": "shellfish",
+    "emoji": "🦪"
+  },
+  {
+    "name": "squid (shellfish)",
+    "allergen": "shellfish",
+    "emoji": "🦑"
+  },
+  {
+    "name": "fish",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "salmon",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "cod",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "tuna",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "mackerel",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "milk",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "cream",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "butter",
+    "allergen": "milk",
+    "emoji": "🧈"
+  },
+  {
+    "name": "yogurt",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "mozzarella",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "parmesan",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "cheese",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "cream cheese",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "egg",
+    "allergen": "egg",
+    "emoji": "🥚"
+  },
+  {
+    "name": "soy sauce",
+    "allergen": "soy",
+    "emoji": "🫘"
+  },
+  {
+    "name": "tofu",
+    "allergen": "soy",
+    "emoji": "🫘"
+  },
+  {
+    "name": "wheat",
+    "allergen": "wheat",
+    "emoji": "🌾"
+  },
+  {
+    "name": "wheat dough",
+    "allergen": "wheat",
+    "emoji": "🌾"
+  },
+  {
+    "name": "wheat flour",
+    "allergen": "wheat",
+    "emoji": "🌾"
+  },
+  {
+    "name": "wheat pasta",
+    "allergen": "wheat",
+    "emoji": "🍝"
+  },
+  {
+    "name": "wheat spaghetti",
+    "allergen": "wheat",
+    "emoji": "🍝"
+  },
+  {
+    "name": "wheat penne",
+    "allergen": "wheat",
+    "emoji": "🍝"
+  },
+  {
+    "name": "wheat macaroni",
+    "allergen": "wheat",
+    "emoji": "🍝"
+  },
+  {
+    "name": "wheat ramen",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "udon wheat noodles",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "wheat soba",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "wheat panko",
+    "allergen": "wheat",
+    "emoji": "🥯"
+  },
+  {
+    "name": "wheat bread",
+    "allergen": "wheat",
+    "emoji": "🍞"
+  },
+  {
+    "name": "wheat bun",
+    "allergen": "wheat",
+    "emoji": "🍞"
+  },
+  {
+    "name": "wheat tortillas",
+    "allergen": "wheat",
+    "emoji": "🌯"
+  },
+  {
+    "name": "wheat pita",
+    "allergen": "wheat",
+    "emoji": "🫓"
+  },
+  {
+    "name": "wheat wonton wrappers",
+    "allergen": "wheat",
+    "emoji": "🥟"
+  },
+  {
+    "name": "wheat berries",
+    "allergen": "wheat",
+    "emoji": "🌾"
+  },
+  {
+    "name": "wheat crumbs",
+    "allergen": "wheat",
+    "emoji": "🍞"
+  },
+  {
+    "name": "wheat starch",
+    "allergen": "wheat",
+    "emoji": "🌾"
+  },
+  {
+    "name": "italian sausage",
+    "allergen": "italian_sausage",
+    "emoji": "🌭"
+  },
+  {
+    "name": "nori",
+    "allergen": "",
+    "emoji": "🍘"
+  },
+  {
+    "name": "rice",
+    "allergen": "",
+    "emoji": "🍚"
+  },
+  {
+    "name": "pita bread",
+    "allergen": "wheat",
+    "emoji": "🫓"
+  },
+  {
+    "name": "tomato",
+    "allergen": "",
+    "emoji": "🍅"
+  },
+  {
+    "name": "basil",
+    "allergen": "",
+    "emoji": "🌿"
+  },
+  {
+    "name": "olive oil",
+    "allergen": "",
+    "emoji": "🫒"
+  },
+  {
+    "name": "mayonnaise",
+    "allergen": "",
+    "emoji": "🧴"
+  },
+  {
+    "name": "avocado",
+    "allergen": "",
+    "emoji": "🥑"
+  },
+  {
+    "name": "chicken",
+    "allergen": "",
+    "emoji": "🍗"
+  },
+  {
+    "name": "beef",
+    "allergen": "",
+    "emoji": "🥩"
+  },
+  {
+    "name": "pork",
+    "allergen": "",
+    "emoji": "🥩"
+  },
+  {
+    "name": "garlic",
+    "allergen": "",
+    "emoji": "🧄"
+  },
+  {
+    "name": "onion",
+    "allergen": "",
+    "emoji": "🧅"
+  },
+  {
+    "name": "cucumber",
+    "allergen": "",
+    "emoji": "🥒"
+  },
+  {
+    "name": "eggplant",
+    "allergen": "",
+    "emoji": "🍆"
+  },
+  {
+    "name": "potato",
+    "allergen": "",
+    "emoji": "🥔"
+  },
+  {
+    "name": "carrot",
+    "allergen": "",
+    "emoji": "🥕"
+  },
+  {
+    "name": "scallions",
+    "allergen": "",
+    "emoji": "🧅"
+  },
+  {
+    "name": "lime",
+    "allergen": "",
+    "emoji": "🍋"
+  },
+  {
+    "name": "lemon",
+    "allergen": "",
+    "emoji": "🍋"
+  },
+  {
+    "name": "cheddar",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "clams",
+    "allergen": "shellfish",
+    "emoji": "🦪"
+  },
+  {
+    "name": "fish sauce",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "wheat noodles",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "crema",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "ricotta",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "tzatziki",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "corn tortillas",
+    "allergen": "",
+    "emoji": "🌮"
+  },
+  {
+    "name": "bread crumbs",
+    "allergen": "wheat",
+    "emoji": "🍞"
+  },
+  {
+    "name": "rice noodles",
+    "allergen": "",
+    "emoji": "🍜"
+  },
+  {
+    "name": "anchovy fish sauce",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "bacon",
+    "allergen": "",
+    "emoji": "🥓"
+  },
+  {
+    "name": "banana",
+    "allergen": "",
+    "emoji": "🍌"
+  },
+  {
+    "name": "beef patty",
+    "allergen": "",
+    "emoji": "🍔"
+  },
+  {
+    "name": "bread",
+    "allergen": "wheat",
+    "emoji": "🍞"
+  },
+  {
+    "name": "cabbage",
+    "allergen": "",
+    "emoji": "🥬"
+  },
+  {
+    "name": "celery",
+    "allergen": "",
+    "emoji": "🥬"
+  },
+  {
+    "name": "chicken cutlet",
+    "allergen": "",
+    "emoji": "🍗"
+  },
+  {
+    "name": "chicken wings",
+    "allergen": "",
+    "emoji": "🍗"
+  },
+  {
+    "name": "chickpeas",
+    "allergen": "",
+    "emoji": "🫘"
+  },
+  {
+    "name": "chili",
+    "allergen": "",
+    "emoji": "🌶️"
+  },
+  {
+    "name": "chili oil",
+    "allergen": "",
+    "emoji": "🌶️"
+  },
+  {
+    "name": "chutney",
+    "allergen": "",
+    "emoji": "🫙"
+  },
+  {
+    "name": "coconut",
+    "allergen": "",
+    "emoji": "🥥"
+  },
+  {
+    "name": "coconut milk",
+    "allergen": "",
+    "emoji": "🥥"
+  },
+  {
+    "name": "condensed milk",
+    "allergen": "milk",
+    "emoji": "🥛"
+  },
+  {
+    "name": "curry sauce",
+    "allergen": "",
+    "emoji": "🍛"
+  },
+  {
+    "name": "feta",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "feta cheese",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "green curry paste",
+    "allergen": "",
+    "emoji": "🥫"
+  },
+  {
+    "name": "grilled chicken",
+    "allergen": "",
+    "emoji": "🍗"
+  },
+  {
+    "name": "ham",
+    "allergen": "",
+    "emoji": "🍖"
+  },
+  {
+    "name": "herbs",
+    "allergen": "",
+    "emoji": "🌿"
+  },
+  {
+    "name": "honey",
+    "allergen": "",
+    "emoji": "🍯"
+  },
+  {
+    "name": "imitation crab",
+    "allergen": "fish",
+    "emoji": "🦀"
+  },
+  {
+    "name": "jelly",
+    "allergen": "",
+    "emoji": "🍇"
+  },
+  {
+    "name": "lamb",
+    "allergen": "",
+    "emoji": "🐑"
+  },
+  {
+    "name": "lettuce",
+    "allergen": "",
+    "emoji": "🥬"
+  },
+  {
+    "name": "mirin",
+    "allergen": "",
+    "emoji": "🍶"
+  },
+  {
+    "name": "paneer (milk)",
+    "allergen": "milk",
+    "emoji": "🧀"
+  },
+  {
+    "name": "parsley",
+    "allergen": "",
+    "emoji": "🌿"
+  },
+  {
+    "name": "peas",
+    "allergen": "",
+    "emoji": "🫛"
+  },
+  {
+    "name": "pickles",
+    "allergen": "",
+    "emoji": "🥒"
+  },
+  {
+    "name": "pork cutlet",
+    "allergen": "",
+    "emoji": "🐖"
+  },
+  {
+    "name": "salsa",
+    "allergen": "",
+    "emoji": "🫑"
+  },
+  {
+    "name": "sesame bagel",
+    "allergen": "wheat",
+    "emoji": "🥯"
+  },
+  {
+    "name": "sev wheat",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "spices",
+    "allergen": "",
+    "emoji": "🧂"
+  },
+  {
+    "name": "squid",
+    "allergen": "shellfish",
+    "emoji": "🦑"
+  },
+  {
+    "name": "stock",
+    "allergen": "",
+    "emoji": "🥣"
+  },
+  {
+    "name": "sugar",
+    "allergen": "",
+    "emoji": "🍬"
+  },
+  {
+    "name": "sushi rice",
+    "allergen": "",
+    "emoji": "🍙"
+  },
+  {
+    "name": "tamarind",
+    "allergen": "",
+    "emoji": "🟤"
+  },
+  {
+    "name": "tomato sauce",
+    "allergen": "",
+    "emoji": "🍅"
+  },
+  {
+    "name": "trout",
+    "allergen": "fish",
+    "emoji": "🐟"
+  },
+  {
+    "name": "wasabi",
+    "allergen": "",
+    "emoji": "🟢"
+  },
+  {
+    "name": "wheat baguette",
+    "allergen": "wheat",
+    "emoji": "🥖"
+  },
+  {
+    "name": "wheat biscuit",
+    "allergen": "wheat",
+    "emoji": "🍪"
+  },
+  {
+    "name": "wheat croutons",
+    "allergen": "wheat",
+    "emoji": "🥖"
+  },
+  {
+    "name": "wheat fettuccine",
+    "allergen": "wheat",
+    "emoji": "🍝"
+  },
+  {
+    "name": "wheat flatbread",
+    "allergen": "wheat",
+    "emoji": "🫓"
+  },
+  {
+    "name": "wheat gnocchi",
+    "allergen": "wheat",
+    "emoji": "🥟"
+  },
+  {
+    "name": "wheat naan",
+    "allergen": "wheat",
+    "emoji": "🫓"
+  },
+  {
+    "name": "wheat roll",
+    "allergen": "wheat",
+    "emoji": "🥖"
+  },
+  {
+    "name": "wheat tempura",
+    "allergen": "wheat",
+    "emoji": "🍤"
+  },
+  {
+    "name": "wheat tortilla",
+    "allergen": "wheat",
+    "emoji": "🌯"
+  },
+  {
+    "name": "wheat udon",
+    "allergen": "wheat",
+    "emoji": "🍜"
+  },
+  {
+    "name": "wheat wrappers",
+    "allergen": "wheat",
+    "emoji": "🥟"
+  },
+  {
+    "name": "white wine",
+    "allergen": "",
+    "emoji": "🍷"
+  }
 ]
-


### PR DESCRIPTION
## Summary
- add emoji and allergen metadata for every ingredient referenced by dishes, including meats, produce, sauces, and wheat variants that previously lacked catalog entries
- extend the cuisine-to-flag catalog with Mediterranean, fusion, breakfast, and other missing categories so every dish can show an icon
- verify the updated catalogs resolve all dishes without missing ingredient or cuisine references

## Testing
- python - <<'PY'
import json
with open('data/dishes.json') as f:
    dishes = json.load(f)
with open('data/ingredients.json') as f:
    ingredients = json.load(f)
with open('data/countries.json') as f:
    countries = json.load(f)
missing_ingredients = sorted({ing for dish in dishes for ing in dish['ingredients']} - {item['name'] for item in ingredients})
missing_cuisines = sorted({dish['cuisine'] for dish in dishes} - {item['cuisine'] for item in countries})
print('Missing ingredients:', missing_ingredients)
print('Missing cuisines:', missing_cuisines)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c90d46a1a88327b50dba864884c80a