### PR TITLE
Add avatar assets and header menu

### DIFF
--- a/assets/avatars/adventurous-boy.svg
+++ b/assets/avatars/adventurous-boy.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="adventurousHair" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#2d3436"/>
+      <stop offset="1" stop-color="#636e72"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="#f7efe1" stroke="#222" stroke-width="4"/>
+  <path d="M18 66c4-34 28-50 42-50s38 16 42 50c0 2-2 4-4 4-30-8-48-8-76 0-2 0-4-2-4-4z" fill="url(#adventurousHair)" stroke="#222" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="44" cy="62" r="7" fill="#222"/>
+  <circle cx="76" cy="62" r="7" fill="#222"/>
+  <path d="M46 90c8 6 20 6 28 0" fill="none" stroke="#b55400" stroke-width="5" stroke-linecap="round"/>
+  <rect x="40" y="96" width="40" height="8" rx="4" fill="#1e90ff" stroke="#222" stroke-width="3"/>
+</svg>

--- a/assets/avatars/creative-boy.svg
+++ b/assets/avatars/creative-boy.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="creativeHair" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ff6f61"/>
+      <stop offset="1" stop-color="#ff9472"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="#fef5f1" stroke="#222" stroke-width="4"/>
+  <path d="M60 18c-20 0-32 12-34 32l-2 16c0 4 4 6 8 6 12-2 24-2 54 0 4 0 8-2 8-6l-2-16c-2-20-14-32-32-32z" fill="url(#creativeHair)" stroke="#222" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="46" cy="64" r="6" fill="#222"/>
+  <circle cx="74" cy="64" r="6" fill="#222"/>
+  <path d="M44 86c10 6 22 6 32 0" fill="none" stroke="#c0392b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M32 48c8-12 24-14 28-14s20 2 28 14" fill="none" stroke="#222" stroke-width="5" stroke-linecap="round"/>
+  <rect x="32" y="98" width="56" height="12" rx="6" fill="#ffd166" stroke="#222" stroke-width="3"/>
+</svg>

--- a/assets/avatars/curious-girl.svg
+++ b/assets/avatars/curious-girl.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="curiousHair" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#6a4c93"/>
+      <stop offset="1" stop-color="#8a67c4"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="#fce4ec" stroke="#222" stroke-width="4"/>
+  <path d="M20 66c0-30 18-46 40-46s40 16 40 46-18 46-40 46-40-16-40-46z" fill="url(#curiousHair)" stroke="#222" stroke-width="4"/>
+  <circle cx="45" cy="62" r="7" fill="#222"/>
+  <circle cx="75" cy="62" r="7" fill="#222"/>
+  <path d="M46 98c8-8 20-8 28 0" fill="none" stroke="#d46a6a" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="60" cy="38" r="14" fill="#fce4ec" stroke="#222" stroke-width="4"/>
+  <path d="M38 42c6-8 18-10 22-10 4 0 16 2 22 10" fill="none" stroke="#222" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/assets/avatars/sunny-girl.svg
+++ b/assets/avatars/sunny-girl.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="sunnyHair" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ffb347"/>
+      <stop offset="1" stop-color="#ffcc33"/>
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="#fdf1d0" stroke="#222" stroke-width="4"/>
+  <path d="M60 12c-24 0-44 18-44 40v20c0 6 6 10 12 8 14-4 32-6 64 0 8 2 12-4 12-12V52C104 30 84 12 60 12z" fill="url(#sunnyHair)" stroke="#222" stroke-width="4" stroke-linejoin="round"/>
+  <ellipse cx="60" cy="84" rx="22" ry="16" fill="#ffe0e8" stroke="#222" stroke-width="3"/>
+  <circle cx="44" cy="60" r="6" fill="#222"/>
+  <circle cx="76" cy="60" r="6" fill="#222"/>
+  <path d="M48 92c6 6 18 6 24 0" fill="none" stroke="#d46a6a" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="34" cy="50" r="6" fill="#f6d365" stroke="#222" stroke-width="3"/>
+  <circle cx="86" cy="50" r="6" fill="#f6d365" stroke="#222" stroke-width="3"/>
+</svg>

--- a/constants.js
+++ b/constants.js
@@ -9,12 +9,25 @@ export const ScreenName = Object.freeze({
 const WheelControlModeStringStop = "stop";
 const WheelControlModeStringStart = "start";
 
+const AvatarIdentifierSunnyGirl = "avatar-sunny-girl";
+const AvatarIdentifierCuriousGirl = "avatar-curious-girl";
+const AvatarIdentifierAdventurousBoy = "avatar-adventurous-boy";
+const AvatarIdentifierCreativeBoy = "avatar-creative-boy";
+
 export const MODE_STOP = WheelControlModeStringStop;
 export const MODE_START = WheelControlModeStringStart;
 
 export const WheelControlMode = Object.freeze({
     STOP: WheelControlModeStringStop,
     START: WheelControlModeStringStart
+});
+
+export const AvatarId = Object.freeze({
+    DEFAULT: AvatarIdentifierSunnyGirl,
+    SUNNY_GIRL: AvatarIdentifierSunnyGirl,
+    CURIOUS_GIRL: AvatarIdentifierCuriousGirl,
+    ADVENTUROUS_BOY: AvatarIdentifierAdventurousBoy,
+    CREATIVE_BOY: AvatarIdentifierCreativeBoy
 });
 
 export const ControlElementId = Object.freeze({

--- a/index.html
+++ b/index.html
@@ -57,7 +57,87 @@
         }
 
         header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
+        .header-left { display: flex; align-items: center; gap: 14px; }
         .header-right { display: flex; align-items: center; gap: 12px; }
+
+        .avatar-menu-wrapper { position: relative; }
+
+        .avatar-button {
+            width: 58px;
+            height: 58px;
+            border-radius: 50%;
+            border: 3px solid #000;
+            background: #fff;
+            box-shadow: 3px 3px 0 #000;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 6px;
+            cursor: pointer;
+            transition: transform 180ms ease, box-shadow 180ms ease;
+        }
+
+        .avatar-button:hover,
+        .avatar-button:focus-visible {
+            transform: translateY(-1px) scale(1.03);
+            box-shadow: 4px 5px 0 #000;
+            outline: none;
+        }
+
+        .avatar-image { width: 100%; height: 100%; border-radius: 50%; display: block; }
+
+        #avatar-menu {
+            position: absolute;
+            top: calc(100% + 8px);
+            left: 0;
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 8px;
+            padding: 12px;
+            background: #fff;
+            border: 3px solid #000;
+            border-radius: 20px;
+            box-shadow: var(--shadow);
+            min-width: 148px;
+            opacity: 0;
+            transform: translateY(-12px) scale(.96);
+            pointer-events: none;
+        }
+
+        #avatar-menu[hidden] { display: none; }
+
+        #avatar-menu.is-open {
+            animation: avatar-menu-show 180ms ease-out forwards;
+            pointer-events: auto;
+        }
+
+        #avatar-menu.is-closing {
+            animation: avatar-menu-hide 160ms ease-in forwards;
+        }
+
+        .avatar-option { width: 58px; height: 58px; }
+
+        @keyframes avatar-menu-show {
+            0% { opacity: 0; transform: translateY(-12px) scale(.96); }
+            100% { opacity: 1; transform: translateY(0) scale(1); }
+        }
+
+        @keyframes avatar-menu-hide {
+            0% { opacity: 1; transform: translateY(0) scale(1); }
+            100% { opacity: 0; transform: translateY(-12px) scale(.96); }
+        }
+
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
 
         .ghost {
             background: #fff;
@@ -256,7 +336,33 @@
 
 <body data-screen="allergy">
 <header>
-    <h1>Allergy Wheel</h1>
+    <div class="header-left">
+        <div class="avatar-menu-wrapper">
+            <button aria-expanded="false" aria-haspopup="true" class="avatar-button" id="avatar-toggle" type="button">
+                <span class="visually-hidden">Choose your avatar</span>
+                <img alt="Sunny girl avatar" class="avatar-image" src="assets/avatars/sunny-girl.svg"/>
+            </button>
+            <div class="avatar-menu" id="avatar-menu" hidden>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-sunny-girl" type="button">
+                    <span class="visually-hidden">Sunny girl</span>
+                    <img alt="Sunny girl avatar option" class="avatar-image" src="assets/avatars/sunny-girl.svg"/>
+                </button>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-curious-girl" type="button">
+                    <span class="visually-hidden">Curious girl</span>
+                    <img alt="Curious girl avatar option" class="avatar-image" src="assets/avatars/curious-girl.svg"/>
+                </button>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-adventurous-boy" type="button">
+                    <span class="visually-hidden">Adventurous boy</span>
+                    <img alt="Adventurous boy avatar option" class="avatar-image" src="assets/avatars/adventurous-boy.svg"/>
+                </button>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-creative-boy" type="button">
+                    <span class="visually-hidden">Creative boy</span>
+                    <img alt="Creative boy avatar option" class="avatar-image" src="assets/avatars/creative-boy.svg"/>
+                </button>
+            </div>
+        </div>
+        <h1>Allergy Wheel</h1>
+    </div>
     <div class="header-right">
         <div aria-live="polite" class="hearts" id="hearts-bar" title="Hearts"></div>
         <button class="ghost" id="fs">Full Screen</button>


### PR DESCRIPTION
## Summary
- add four kid-friendly avatar SVG illustrations and expose their identifiers
- update constants with an `AvatarId` enum including a default selection
- enhance the header with an avatar toggle button, dropdown markup, and styles for animated positioning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92d83e7b083279b938df21282cc2f