### PR TITLE
Add avatar selection management

### DIFF
--- a/state.js
+++ b/state.js
@@ -1,4 +1,4 @@
-import { WheelControlMode } from "./constants.js";
+import { WheelControlMode, AvatarId } from "./constants.js";
 
 const DEFAULT_INITIAL_HEARTS_COUNT = 5;
 
@@ -10,6 +10,8 @@ const StateManagerErrorMessage = Object.freeze({
     INVALID_INITIAL_HEARTS_COUNT: "StateManager.initialize requires a numeric initialHeartsCount",
     INVALID_HEARTS_COUNT: "StateManager.setHeartsCount requires a numeric value"
 });
+
+const ValidAvatarIdentifierSet = new Set(Object.values(AvatarId));
 
 class StateManager {
     #board;
@@ -27,6 +29,8 @@ class StateManager {
     #wheelCandidateLabels;
 
     #stopButtonMode;
+
+    #selectedAvatarId = AvatarId.DEFAULT;
 
     constructor({
         initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT,
@@ -53,6 +57,7 @@ class StateManager {
         this.#wheelCandidateDishes = [];
         this.#wheelCandidateLabels = [];
         this.#board = null;
+        this.#selectedAvatarId = AvatarId.DEFAULT;
     }
 
     setBoard(boardInstance) {
@@ -135,6 +140,22 @@ class StateManager {
 
     getStopButtonMode() {
         return this.#stopButtonMode;
+    }
+
+    setSelectedAvatar(avatarId) {
+        const validatedAvatarIdentifier =
+            typeof avatarId === "string" && ValidAvatarIdentifierSet.has(avatarId)
+                ? avatarId
+                : AvatarId.DEFAULT;
+        this.#selectedAvatarId = validatedAvatarIdentifier;
+    }
+
+    getSelectedAvatar() {
+        return this.#selectedAvatarId;
+    }
+
+    hasSelectedAvatar() {
+        return ValidAvatarIdentifierSet.has(this.#selectedAvatarId);
     }
 }
 


### PR DESCRIPTION
## Summary
- add avatar selection state to `StateManager`, including validation and accessors
- ensure initialization resets the selected avatar to the default identifier
- expand unit coverage with table-driven avatar selection scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e51194688327a51127f2a21f62ae