### PR TITLE
Add avatar selector interactions

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,8 @@ import {
     FirstCardElementId,
     ResultCardElementId,
     AvatarId,
-    AvatarAssetPath
+    AvatarAssetPath,
+    AvatarClassName
 } from "./constants.js";
 
 const stateManager = new StateManager();
@@ -89,6 +90,22 @@ const revealCardPresenter = new ResultCard({
     selectedAvatarId: stateManager.getSelectedAvatar()
 });
 
+const headerAvatarToggleElement = document.getElementById(ControlElementId.AVATAR_TOGGLE);
+const headerAvatarImageElement = headerAvatarToggleElement
+    ? headerAvatarToggleElement.getElementsByClassName(AvatarClassName.IMAGE)[0] || null
+    : null;
+
+const updateHeaderAvatarImage = (avatarIdentifier) => {
+    if (!headerAvatarImageElement) {
+        return;
+    }
+    const resolvedAvatarResource =
+        avatarResourceMap.get(avatarIdentifier) || avatarResourceMap.get(AvatarId.DEFAULT);
+    if (resolvedAvatarResource) {
+        headerAvatarImageElement.src = resolvedAvatarResource;
+    }
+};
+
 const heartsPresenter = {
     renderHearts,
     animateHeartGainFromReveal,
@@ -134,6 +151,17 @@ const gameController = new GameController({
 });
 
 stateManager.initialize();
+
+listenerBinder.wireAvatarSelector({
+    onAvatarChange: (avatarIdentifier) => {
+        stateManager.setSelectedAvatar(avatarIdentifier);
+        const resolvedAvatarIdentifier = stateManager.getSelectedAvatar();
+        revealCardPresenter.updateAvatarSelection(resolvedAvatarIdentifier);
+        updateHeaderAvatarImage(resolvedAvatarIdentifier);
+    }
+});
+
+updateHeaderAvatarImage(stateManager.getSelectedAvatar());
 
 window.addEventListener(BrowserEventName.DOM_CONTENT_LOADED, () => {
     gameController.bootstrap();

--- a/constants.js
+++ b/constants.js
@@ -49,7 +49,22 @@ export const ControlElementId = Object.freeze({
     SPIN_AGAIN_BUTTON: "again",
     REVEAL_SECTION: "reveal",
     GAME_OVER_SECTION: "gameover",
-    RESTART_BUTTON: "restart"
+    RESTART_BUTTON: "restart",
+    AVATAR_TOGGLE: "avatar-toggle",
+    AVATAR_MENU: "avatar-menu"
+});
+
+const AvatarOptionClassName = "avatar-option";
+const AvatarImageClassName = "avatar-image";
+const AvatarMenuOpenClassName = "is-open";
+
+export const AvatarClassName = Object.freeze({
+    OPTION: AvatarOptionClassName,
+    IMAGE: AvatarImageClassName
+});
+
+export const AvatarMenuClassName = Object.freeze({
+    OPEN: AvatarMenuOpenClassName
 });
 
 export const FirstCardElementId = Object.freeze({
@@ -83,7 +98,8 @@ export const AttributeName = Object.freeze({
     ARIA_HIDDEN: "aria-hidden",
     DATA_SCREEN: "data-screen",
     DATA_COUNT: "data-count",
-    ARIA_LABEL: "aria-label"
+    ARIA_LABEL: "aria-label",
+    ARIA_EXPANDED: "aria-expanded"
 });
 
 export const AttributeBooleanValue = Object.freeze({

--- a/listeners.js
+++ b/listeners.js
@@ -1,4 +1,11 @@
-import { WheelControlMode, BrowserEventName, KeyboardKey, AttributeBooleanValue } from "./constants.js";
+import {
+    WheelControlMode,
+    BrowserEventName,
+    KeyboardKey,
+    AttributeBooleanValue,
+    AvatarClassName,
+    AvatarMenuClassName
+} from "./constants.js";
 
 const ListenerErrorMessage = {
     MISSING_DEPENDENCIES: "createListenerBinder requires controlElementId, attributeName, and stateManager",
@@ -91,13 +98,67 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
         });
     }
 
+    function wireAvatarSelector({ onAvatarChange }) {
+        const avatarToggleButton = documentReference.getElementById(controlElementId.AVATAR_TOGGLE);
+        const avatarMenuElement = documentReference.getElementById(controlElementId.AVATAR_MENU);
+        if (!avatarToggleButton || !avatarMenuElement) {
+            return;
+        }
+
+        const menuOpenClassName = AvatarMenuClassName.OPEN;
+        const ariaExpandedAttributeName = attributeName.ARIA_EXPANDED;
+
+        const setMenuVisibility = (shouldShowMenu) => {
+            if (shouldShowMenu) {
+                avatarMenuElement.hidden = false;
+                if (menuOpenClassName) {
+                    avatarMenuElement.classList.add(menuOpenClassName);
+                }
+                if (ariaExpandedAttributeName) {
+                    avatarToggleButton.setAttribute(ariaExpandedAttributeName, AttributeBooleanValue.TRUE);
+                }
+            } else {
+                if (menuOpenClassName) {
+                    avatarMenuElement.classList.remove(menuOpenClassName);
+                }
+                avatarMenuElement.hidden = true;
+                if (ariaExpandedAttributeName) {
+                    avatarToggleButton.setAttribute(ariaExpandedAttributeName, AttributeBooleanValue.FALSE);
+                }
+            }
+        };
+
+        setMenuVisibility(false);
+
+        avatarToggleButton.addEventListener(BrowserEventName.CLICK, () => {
+            const shouldOpenMenu = avatarMenuElement.hidden;
+            setMenuVisibility(shouldOpenMenu);
+        });
+
+        const avatarOptionClassName = AvatarClassName.OPTION;
+        const avatarOptionElements = avatarOptionClassName
+            ? Array.from(avatarMenuElement.getElementsByClassName(avatarOptionClassName))
+            : [];
+
+        for (const avatarOptionElement of avatarOptionElements) {
+            avatarOptionElement.addEventListener(BrowserEventName.CLICK, () => {
+                const selectedAvatarIdentifier = avatarOptionElement.dataset.avatarId;
+                if (typeof onAvatarChange === "function" && selectedAvatarIdentifier) {
+                    onAvatarChange(selectedAvatarIdentifier);
+                }
+                setMenuVisibility(false);
+            });
+        }
+    }
+
     return {
         wireStartButton,
         wireStopButton,
         wireFullscreenButton,
         wireSpinAgainButton,
         wireRevealBackdropDismissal,
-        wireRestartButton
+        wireRestartButton,
+        wireAvatarSelector
     };
 }
 

--- a/tests/integration/avatarSelection.integration.test.js
+++ b/tests/integration/avatarSelection.integration.test.js
@@ -1,0 +1,314 @@
+import { createListenerBinder } from "../../listeners.js";
+import { StateManager } from "../../state.js";
+import { ResultCard } from "../../lastCard.js";
+import {
+  ControlElementId,
+  AttributeName,
+  AttributeBooleanValue,
+  ResultCardElementId,
+  AvatarId,
+  AvatarAssetPath,
+  AvatarClassName
+} from "../../constants.js";
+
+const EmptyStringValue = "";
+const SvgNamespaceUri = "http://www.w3.org/2000/svg";
+
+const HtmlTagName = Object.freeze({
+  BUTTON: "button",
+  DIV: "div",
+  IMG: "img",
+  SECTION: "section",
+  SVG: "svg"
+});
+
+const HtmlAttributeName = Object.freeze({
+  SRC: "src"
+});
+
+const SvgSelector = Object.freeze({
+  IMAGE: "image"
+});
+
+const SvgAttributeName = Object.freeze({
+  HREF: "href"
+});
+
+const RevealSectionClassName = Object.freeze({
+  ACTIONS: "actions"
+});
+
+const TestAllergenDescriptor = Object.freeze({
+  TOKEN: "peanut",
+  LABEL: "Peanut",
+  EMOJI: "🥜"
+});
+
+const DishDescriptor = Object.freeze({
+  NAME: "Peanut Satay",
+  EMOJI: "🥜",
+  HAZARDOUS_INGREDIENT: "peanut"
+});
+
+const AvatarResourceEntries = Object.freeze([
+  [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
+  [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
+  [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
+  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
+]);
+
+const AvatarSelectionTestDescription = Object.freeze({
+  CREATIVE: "selecting the creative boy avatar renders it on the result card",
+  CURIOUS: "selecting the curious girl avatar renders it on the result card"
+});
+
+const AvatarSelectionTestCases = [
+  { description: AvatarSelectionTestDescription.CREATIVE, chosenAvatarId: AvatarId.CREATIVE_BOY },
+  { description: AvatarSelectionTestDescription.CURIOUS, chosenAvatarId: AvatarId.CURIOUS_GIRL }
+];
+
+afterEach(() => {
+  document.body.innerHTML = EmptyStringValue;
+});
+
+function createAvatarSelectorElements({ avatarResourceEntries, defaultAvatarResource }) {
+  const headerAvatarToggleButtonElement = document.createElement(HtmlTagName.BUTTON);
+  headerAvatarToggleButtonElement.id = ControlElementId.AVATAR_TOGGLE;
+  headerAvatarToggleButtonElement.setAttribute(AttributeName.ARIA_EXPANDED, AttributeBooleanValue.FALSE);
+
+  const headerAvatarImageElement = document.createElement(HtmlTagName.IMG);
+  headerAvatarImageElement.className = AvatarClassName.IMAGE;
+  if (defaultAvatarResource) {
+    headerAvatarImageElement.setAttribute(HtmlAttributeName.SRC, defaultAvatarResource);
+  }
+  headerAvatarToggleButtonElement.appendChild(headerAvatarImageElement);
+
+  const avatarMenuElement = document.createElement(HtmlTagName.DIV);
+  avatarMenuElement.id = ControlElementId.AVATAR_MENU;
+  avatarMenuElement.hidden = true;
+
+  for (const [avatarIdentifier, avatarResourcePath] of avatarResourceEntries) {
+    const avatarOptionButtonElement = document.createElement(HtmlTagName.BUTTON);
+    avatarOptionButtonElement.classList.add(AvatarClassName.OPTION);
+    avatarOptionButtonElement.dataset.avatarId = avatarIdentifier;
+
+    const avatarOptionImageElement = document.createElement(HtmlTagName.IMG);
+    avatarOptionImageElement.className = AvatarClassName.IMAGE;
+    avatarOptionImageElement.setAttribute(HtmlAttributeName.SRC, avatarResourcePath);
+    avatarOptionButtonElement.appendChild(avatarOptionImageElement);
+
+    avatarMenuElement.appendChild(avatarOptionButtonElement);
+  }
+
+  document.body.appendChild(headerAvatarToggleButtonElement);
+  document.body.appendChild(avatarMenuElement);
+
+  return {
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarMenuElement
+  };
+}
+
+function createResultCardElements() {
+  const revealSectionElement = document.createElement(HtmlTagName.SECTION);
+  revealSectionElement.id = ResultCardElementId.REVEAL_SECTION;
+  revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+
+  const dishTitleElement = document.createElement(HtmlTagName.DIV);
+  dishTitleElement.id = ResultCardElementId.DISH_TITLE;
+  revealSectionElement.appendChild(dishTitleElement);
+
+  const dishCuisineElement = document.createElement(HtmlTagName.DIV);
+  dishCuisineElement.id = ResultCardElementId.DISH_CUISINE;
+  revealSectionElement.appendChild(dishCuisineElement);
+
+  const resultBannerElement = document.createElement(HtmlTagName.DIV);
+  resultBannerElement.id = ResultCardElementId.RESULT_BANNER;
+  revealSectionElement.appendChild(resultBannerElement);
+
+  const resultTextElement = document.createElement(HtmlTagName.DIV);
+  resultTextElement.id = ResultCardElementId.RESULT_TEXT;
+  resultBannerElement.appendChild(resultTextElement);
+
+  const ingredientsContainerElement = document.createElement(HtmlTagName.DIV);
+  ingredientsContainerElement.id = ResultCardElementId.INGREDIENTS_CONTAINER;
+  revealSectionElement.appendChild(ingredientsContainerElement);
+
+  const faceSvgElement = document.createElementNS(SvgNamespaceUri, HtmlTagName.SVG);
+  faceSvgElement.id = ResultCardElementId.FACE_SVG;
+  revealSectionElement.appendChild(faceSvgElement);
+
+  const actionsContainerElement = document.createElement(HtmlTagName.DIV);
+  actionsContainerElement.className = RevealSectionClassName.ACTIONS;
+  revealSectionElement.appendChild(actionsContainerElement);
+
+  document.body.appendChild(revealSectionElement);
+
+  const gameOverSectionElement = document.createElement(HtmlTagName.SECTION);
+  gameOverSectionElement.id = ResultCardElementId.GAME_OVER_SECTION;
+  gameOverSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+  document.body.appendChild(gameOverSectionElement);
+
+  return {
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement
+  };
+}
+
+function createNormalizationEngineDouble(allergenToken) {
+  return {
+    tokensForIngredient: () => new Set([allergenToken])
+  };
+}
+
+function createAvatarSelectionTestHarness() {
+  const avatarResourceMap = new Map(AvatarResourceEntries);
+  const defaultAvatarResource = avatarResourceMap.get(AvatarId.DEFAULT);
+  const {
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarMenuElement
+  } = createAvatarSelectorElements({
+    avatarResourceEntries: AvatarResourceEntries,
+    defaultAvatarResource
+  });
+
+  const {
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement
+  } = createResultCardElements();
+
+  const stateManager = new StateManager();
+
+  const listenerBinder = createListenerBinder({
+    controlElementId: ControlElementId,
+    attributeName: AttributeName,
+    documentReference: document,
+    stateManager
+  });
+
+  const normalizationEngineDouble = createNormalizationEngineDouble(TestAllergenDescriptor.TOKEN);
+
+  const resultCard = new ResultCard({
+    documentReference: document,
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement,
+    normalizationEngine: normalizationEngineDouble,
+    allergensCatalog: [
+      { token: TestAllergenDescriptor.TOKEN, emoji: TestAllergenDescriptor.EMOJI }
+    ],
+    cuisineToFlagMap: new Map(),
+    ingredientEmojiByName: new Map(),
+    avatarMap: avatarResourceMap,
+    selectedAvatarId: stateManager.getSelectedAvatar()
+  });
+
+  const updateHeaderAvatarImage = (avatarIdentifier) => {
+    const resolvedAvatarResource =
+      avatarResourceMap.get(avatarIdentifier) || avatarResourceMap.get(AvatarId.DEFAULT);
+    if (resolvedAvatarResource) {
+      headerAvatarImageElement.setAttribute(HtmlAttributeName.SRC, resolvedAvatarResource);
+    }
+  };
+
+  updateHeaderAvatarImage(stateManager.getSelectedAvatar());
+
+  return {
+    listenerBinder,
+    stateManager,
+    resultCard,
+    avatarMenuElement,
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarResourceMap,
+    updateHeaderAvatarImage,
+    faceSvgElement
+  };
+}
+
+describe("Avatar selection integration", () => {
+  test.each(AvatarSelectionTestCases)(
+    "$description",
+    ({ chosenAvatarId }) => {
+      const {
+        listenerBinder,
+        stateManager,
+        resultCard,
+        avatarMenuElement,
+        headerAvatarToggleButtonElement,
+        headerAvatarImageElement,
+        avatarResourceMap,
+        updateHeaderAvatarImage,
+        faceSvgElement
+      } = createAvatarSelectionTestHarness();
+
+      listenerBinder.wireAvatarSelector({
+        onAvatarChange: (avatarIdentifier) => {
+          stateManager.setSelectedAvatar(avatarIdentifier);
+          const resolvedAvatarIdentifier = stateManager.getSelectedAvatar();
+          resultCard.updateAvatarSelection(resolvedAvatarIdentifier);
+          updateHeaderAvatarImage(resolvedAvatarIdentifier);
+        }
+      });
+
+      headerAvatarToggleButtonElement.click();
+
+      const avatarOptionElements = Array.from(
+        avatarMenuElement.getElementsByClassName(AvatarClassName.OPTION)
+      );
+      const targetOptionButtonElement = avatarOptionElements.find(
+        (optionElement) => optionElement.dataset.avatarId === chosenAvatarId
+      );
+      expect(targetOptionButtonElement).toBeDefined();
+
+      targetOptionButtonElement.click();
+
+      expect(stateManager.getSelectedAvatar()).toBe(chosenAvatarId);
+      expect(avatarMenuElement.hidden).toBe(true);
+
+      const expectedAvatarResourcePath = avatarResourceMap.get(chosenAvatarId);
+      expect(expectedAvatarResourcePath).toBeDefined();
+
+      const populateResult = resultCard.populateRevealCard({
+        dish: {
+          name: DishDescriptor.NAME,
+          emoji: DishDescriptor.EMOJI,
+          ingredients: [DishDescriptor.HAZARDOUS_INGREDIENT]
+        },
+        selectedAllergenToken: TestAllergenDescriptor.TOKEN,
+        selectedAllergenLabel: TestAllergenDescriptor.LABEL
+      });
+
+      expect(populateResult.hasTriggeringIngredient).toBe(true);
+      expect(faceSvgElement.hidden).toBe(false);
+      expect(headerAvatarImageElement.getAttribute(HtmlAttributeName.SRC)).toBe(
+        expectedAvatarResourcePath
+      );
+
+      const renderedAvatarImageElement = faceSvgElement.querySelector(SvgSelector.IMAGE);
+      expect(renderedAvatarImageElement).not.toBeNull();
+      expect(renderedAvatarImageElement.getAttribute(SvgAttributeName.HREF)).toBe(
+        expectedAvatarResourcePath
+      );
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add avatar selector wiring that toggles the menu and notifies avatar changes
- update the application bootstrap to synchronize header imagery and result cards with the selected avatar
- extend constants to cover avatar control identifiers and selectors, and add an integration test covering avatar rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ea9e4ce48327ab2cf0bebbcc7ee2