### PR TITLE
Add integration test for avatar selection persistence

### DIFF
--- a/tests/integration/avatarSelection.test.js
+++ b/tests/integration/avatarSelection.test.js
@@ -1,0 +1,355 @@
+import { createListenerBinder } from "../../listeners.js";
+import { StateManager } from "../../state.js";
+import { ResultCard } from "../../lastCard.js";
+import {
+  ControlElementId,
+  AttributeName,
+  AttributeBooleanValue,
+  ResultCardElementId,
+  AvatarId,
+  AvatarAssetPath,
+  AvatarClassName
+} from "../../constants.js";
+
+const EmptyStringValue = "";
+const SvgNamespaceUri = "http://www.w3.org/2000/svg";
+
+const HtmlTagName = Object.freeze({
+  BUTTON: "button",
+  DIV: "div",
+  IMG: "img",
+  SECTION: "section",
+  SVG: "svg"
+});
+
+const HtmlAttributeName = Object.freeze({
+  SRC: "src"
+});
+
+const SvgSelector = Object.freeze({
+  IMAGE: "image"
+});
+
+const SvgAttributeName = Object.freeze({
+  HREF: "href"
+});
+
+const RevealSectionClassName = Object.freeze({
+  ACTIONS: "actions"
+});
+
+const TestAllergenDescriptor = Object.freeze({
+  TOKEN: "peanut",
+  LABEL: "Peanut",
+  EMOJI: "🥜"
+});
+
+const DishDescriptor = Object.freeze({
+  FIRST_ROUND: {
+    NAME: "Peanut Satay",
+    EMOJI: "🥜",
+    HAZARDOUS_INGREDIENT: "peanut"
+  },
+  SECOND_ROUND: {
+    NAME: "Almond Cookie",
+    EMOJI: "🍪",
+    HAZARDOUS_INGREDIENT: "peanut"
+  }
+});
+
+const AvatarResourceEntries = Object.freeze([
+  [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
+  [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
+  [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
+  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
+]);
+
+const AvatarSelectionScenarioDescription = Object.freeze({
+  CREATIVE_PERSISTENCE: "selecting the creative boy avatar persists across rounds"
+});
+
+const AvatarSelectionScenarios = [
+  {
+    description: AvatarSelectionScenarioDescription.CREATIVE_PERSISTENCE,
+    chosenAvatarId: AvatarId.CREATIVE_BOY
+  }
+];
+
+afterEach(() => {
+  document.body.innerHTML = EmptyStringValue;
+});
+
+function createAvatarSelectorElements({ avatarResourceEntries, defaultAvatarResource }) {
+  const headerAvatarToggleButtonElement = document.createElement(HtmlTagName.BUTTON);
+  headerAvatarToggleButtonElement.id = ControlElementId.AVATAR_TOGGLE;
+  headerAvatarToggleButtonElement.setAttribute(
+    AttributeName.ARIA_EXPANDED,
+    AttributeBooleanValue.FALSE
+  );
+
+  const headerAvatarImageElement = document.createElement(HtmlTagName.IMG);
+  headerAvatarImageElement.className = AvatarClassName.IMAGE;
+  if (defaultAvatarResource) {
+    headerAvatarImageElement.setAttribute(HtmlAttributeName.SRC, defaultAvatarResource);
+  }
+  headerAvatarToggleButtonElement.appendChild(headerAvatarImageElement);
+
+  const avatarMenuElement = document.createElement(HtmlTagName.DIV);
+  avatarMenuElement.id = ControlElementId.AVATAR_MENU;
+  avatarMenuElement.hidden = true;
+
+  for (const [avatarIdentifier, avatarResourcePath] of avatarResourceEntries) {
+    const avatarOptionButtonElement = document.createElement(HtmlTagName.BUTTON);
+    avatarOptionButtonElement.classList.add(AvatarClassName.OPTION);
+    avatarOptionButtonElement.dataset.avatarId = avatarIdentifier;
+
+    const avatarOptionImageElement = document.createElement(HtmlTagName.IMG);
+    avatarOptionImageElement.className = AvatarClassName.IMAGE;
+    avatarOptionImageElement.setAttribute(HtmlAttributeName.SRC, avatarResourcePath);
+    avatarOptionButtonElement.appendChild(avatarOptionImageElement);
+
+    avatarMenuElement.appendChild(avatarOptionButtonElement);
+  }
+
+  document.body.appendChild(headerAvatarToggleButtonElement);
+  document.body.appendChild(avatarMenuElement);
+
+  return {
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarMenuElement
+  };
+}
+
+function createResultCardElements() {
+  const revealSectionElement = document.createElement(HtmlTagName.SECTION);
+  revealSectionElement.id = ResultCardElementId.REVEAL_SECTION;
+  revealSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+
+  const dishTitleElement = document.createElement(HtmlTagName.DIV);
+  dishTitleElement.id = ResultCardElementId.DISH_TITLE;
+  revealSectionElement.appendChild(dishTitleElement);
+
+  const dishCuisineElement = document.createElement(HtmlTagName.DIV);
+  dishCuisineElement.id = ResultCardElementId.DISH_CUISINE;
+  revealSectionElement.appendChild(dishCuisineElement);
+
+  const resultBannerElement = document.createElement(HtmlTagName.DIV);
+  resultBannerElement.id = ResultCardElementId.RESULT_BANNER;
+  revealSectionElement.appendChild(resultBannerElement);
+
+  const resultTextElement = document.createElement(HtmlTagName.DIV);
+  resultTextElement.id = ResultCardElementId.RESULT_TEXT;
+  resultBannerElement.appendChild(resultTextElement);
+
+  const ingredientsContainerElement = document.createElement(HtmlTagName.DIV);
+  ingredientsContainerElement.id = ResultCardElementId.INGREDIENTS_CONTAINER;
+  revealSectionElement.appendChild(ingredientsContainerElement);
+
+  const faceSvgElement = document.createElementNS(SvgNamespaceUri, HtmlTagName.SVG);
+  faceSvgElement.id = ResultCardElementId.FACE_SVG;
+  faceSvgElement.hidden = true;
+  revealSectionElement.appendChild(faceSvgElement);
+
+  const actionsContainerElement = document.createElement(HtmlTagName.DIV);
+  actionsContainerElement.className = RevealSectionClassName.ACTIONS;
+  revealSectionElement.appendChild(actionsContainerElement);
+
+  document.body.appendChild(revealSectionElement);
+
+  const gameOverSectionElement = document.createElement(HtmlTagName.SECTION);
+  gameOverSectionElement.id = ResultCardElementId.GAME_OVER_SECTION;
+  gameOverSectionElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+  document.body.appendChild(gameOverSectionElement);
+
+  return {
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement
+  };
+}
+
+function createNormalizationEngineDouble(allergenToken) {
+  return {
+    tokensForIngredient: () => new Set([allergenToken])
+  };
+}
+
+function createDishRecord(dishDescriptor) {
+  return {
+    name: dishDescriptor.NAME,
+    emoji: dishDescriptor.EMOJI,
+    ingredients: [dishDescriptor.HAZARDOUS_INGREDIENT]
+  };
+}
+
+function createAvatarSelectionIntegrationHarness() {
+  const avatarResourceMap = new Map(AvatarResourceEntries);
+  const defaultAvatarResource = avatarResourceMap.get(AvatarId.DEFAULT);
+  const {
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarMenuElement
+  } = createAvatarSelectorElements({
+    avatarResourceEntries: AvatarResourceEntries,
+    defaultAvatarResource
+  });
+
+  const {
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement
+  } = createResultCardElements();
+
+  const stateManager = new StateManager();
+  stateManager.setSelectedAllergen({
+    token: TestAllergenDescriptor.TOKEN,
+    label: TestAllergenDescriptor.LABEL
+  });
+
+  const listenerBinder = createListenerBinder({
+    controlElementId: ControlElementId,
+    attributeName: AttributeName,
+    documentReference: document,
+    stateManager
+  });
+
+  const normalizationEngineDouble = createNormalizationEngineDouble(TestAllergenDescriptor.TOKEN);
+
+  const resultCard = new ResultCard({
+    documentReference: document,
+    revealSectionElement,
+    dishTitleElement,
+    dishCuisineElement,
+    resultBannerElement,
+    resultTextElement,
+    ingredientsContainerElement,
+    faceSvgElement,
+    gameOverSectionElement,
+    normalizationEngine: normalizationEngineDouble,
+    allergensCatalog: [
+      { token: TestAllergenDescriptor.TOKEN, emoji: TestAllergenDescriptor.EMOJI }
+    ],
+    cuisineToFlagMap: new Map(),
+    ingredientEmojiByName: new Map(),
+    avatarMap: avatarResourceMap,
+    selectedAvatarId: stateManager.getSelectedAvatar()
+  });
+
+  const updateHeaderAvatarImage = (avatarIdentifier) => {
+    const resolvedAvatarResource =
+      avatarResourceMap.get(avatarIdentifier) || avatarResourceMap.get(AvatarId.DEFAULT);
+    if (resolvedAvatarResource) {
+      headerAvatarImageElement.setAttribute(HtmlAttributeName.SRC, resolvedAvatarResource);
+    }
+  };
+
+  updateHeaderAvatarImage(stateManager.getSelectedAvatar());
+
+  listenerBinder.wireAvatarSelector({
+    onAvatarChange: (avatarIdentifier) => {
+      stateManager.setSelectedAvatar(avatarIdentifier);
+      const resolvedAvatarIdentifier = stateManager.getSelectedAvatar();
+      resultCard.updateAvatarSelection(resolvedAvatarIdentifier);
+      updateHeaderAvatarImage(resolvedAvatarIdentifier);
+    }
+  });
+
+  const selectAvatar = (avatarIdentifier) => {
+    headerAvatarToggleButtonElement.click();
+    const avatarOptionElements = Array.from(
+      avatarMenuElement.getElementsByClassName(AvatarClassName.OPTION)
+    );
+    return avatarOptionElements.find((optionElement) => optionElement.dataset.avatarId === avatarIdentifier);
+  };
+
+  const simulateSpinAndReveal = (dishDescriptor) => {
+    const dishRecord = createDishRecord(dishDescriptor);
+    stateManager.setWheelCandidates({
+      dishes: [dishRecord],
+      labels: [{ label: dishDescriptor.NAME, emoji: dishDescriptor.EMOJI }]
+    });
+    return resultCard.populateRevealCard({
+      dish: dishRecord,
+      selectedAllergenToken: TestAllergenDescriptor.TOKEN,
+      selectedAllergenLabel: TestAllergenDescriptor.LABEL
+    });
+  };
+
+  const getRenderedAvatarImageElement = () => faceSvgElement.querySelector(SvgSelector.IMAGE);
+
+  return {
+    stateManager,
+    avatarResourceMap,
+    headerAvatarToggleButtonElement,
+    headerAvatarImageElement,
+    avatarMenuElement,
+    faceSvgElement,
+    selectAvatar,
+    simulateSpinAndReveal,
+    getRenderedAvatarImageElement
+  };
+}
+
+describe("Avatar selection persistence", () => {
+  test.each(AvatarSelectionScenarios)("%s", ({ chosenAvatarId }) => {
+    const {
+      stateManager,
+      avatarResourceMap,
+      headerAvatarImageElement,
+      avatarMenuElement,
+      faceSvgElement,
+      selectAvatar,
+      simulateSpinAndReveal,
+      getRenderedAvatarImageElement
+    } = createAvatarSelectionIntegrationHarness();
+
+    const targetOptionButtonElement = selectAvatar(chosenAvatarId);
+    expect(targetOptionButtonElement).toBeDefined();
+    targetOptionButtonElement.click();
+
+    expect(stateManager.getSelectedAvatar()).toBe(chosenAvatarId);
+    expect(avatarMenuElement.hidden).toBe(true);
+
+    const expectedAvatarResourcePath = avatarResourceMap.get(chosenAvatarId);
+    expect(expectedAvatarResourcePath).toBeDefined();
+    expect(headerAvatarImageElement.getAttribute(HtmlAttributeName.SRC)).toBe(
+      expectedAvatarResourcePath
+    );
+
+    const firstSpinResult = simulateSpinAndReveal(DishDescriptor.FIRST_ROUND);
+    expect(firstSpinResult.hasTriggeringIngredient).toBe(true);
+    expect(faceSvgElement.hidden).toBe(false);
+
+    const renderedAvatarImageElement = getRenderedAvatarImageElement();
+    expect(renderedAvatarImageElement).not.toBeNull();
+    expect(renderedAvatarImageElement.getAttribute(SvgAttributeName.HREF)).toBe(
+      expectedAvatarResourcePath
+    );
+
+    const secondSpinResult = simulateSpinAndReveal(DishDescriptor.SECOND_ROUND);
+    expect(secondSpinResult.hasTriggeringIngredient).toBe(true);
+    expect(faceSvgElement.hidden).toBe(false);
+
+    const secondRenderedAvatarImageElement = getRenderedAvatarImageElement();
+    expect(secondRenderedAvatarImageElement).not.toBeNull();
+    expect(secondRenderedAvatarImageElement.getAttribute(SvgAttributeName.HREF)).toBe(
+      expectedAvatarResourcePath
+    );
+
+    expect(stateManager.getSelectedAvatar()).toBe(chosenAvatarId);
+    expect(headerAvatarImageElement.getAttribute(HtmlAttributeName.SRC)).toBe(
+      expectedAvatarResourcePath
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add an integration test that simulates choosing a non-default avatar
- verify the revealed dish renders the selected avatar and that the choice persists across spins

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9ee8c9b708327bdc84e9255f6f86f