### PR TITLE
Document avatar customization and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ npm test
 ```
 
 The Jest harness is configured for a jsdom environment so the integration tests can verify canvas rendering and gameplay flows. All test files live inside the `tests/` directory and are grouped into `unit` and `integration` subdirectories.
+
+## Avatar customization
+
+Players can personalize the result card by choosing from four built-in avatars: Sunny Girl, Curious Girl, Adventurous Boy, and Creative Boy. The currently selected avatar is displayed in the header toggle button and on the allergy result card during the reveal sequence.
+
+To change avatars, click the avatar button in the header to open the selector menu. Choosing any option updates the header image immediately, closes the menu, and persists the selection so the reveal card shows the same avatar until a different option is picked.

--- a/app.js
+++ b/app.js
@@ -95,6 +95,12 @@ const headerAvatarImageElement = headerAvatarToggleElement
     ? headerAvatarToggleElement.getElementsByClassName(AvatarClassName.IMAGE)[0] || null
     : null;
 
+/**
+ * Updates the header avatar image element with the resource mapped to the selected identifier.
+ * Falls back to the default avatar asset when the provided identifier is not available.
+ *
+ * @param {string} avatarIdentifier - Identifier representing the avatar to display.
+ */
 const updateHeaderAvatarImage = (avatarIdentifier) => {
     if (!headerAvatarImageElement) {
         return;

--- a/doc/avatars.md
+++ b/doc/avatars.md
@@ -1,0 +1,13 @@
+# Avatar assets
+
+The SVG illustrations stored in `assets/avatars/` were custom-created for this project. They may be used within the Allergy Wheel
+experience under the same license that governs the rest of the repository. Please reach out to the maintainers before reusing the
+artwork in other projects if the repository license does not cover your intended use.
+
+## Contributing new avatars
+
+- Submit only artwork that you created yourself or that you have explicit permission to redistribute with attribution details.
+- Provide vector SVG files optimized for the web (remove unnecessary metadata and keep file sizes low).
+- Include a note in your pull request describing the source of the artwork and the licensing terms.
+- Update any relevant constants, tests, and documentation so the new avatar appears in the selector UI and remains fully covered
+  by automated checks.

--- a/listeners.js
+++ b/listeners.js
@@ -98,6 +98,11 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
         });
     }
 
+    /**
+     * Connects avatar menu interactions to application state updates.
+     *
+     * @param {{ onAvatarChange: (avatarIdentifier: string) => void }} param0 - Callbacks invoked during avatar selection.
+     */
     function wireAvatarSelector({ onAvatarChange }) {
         const avatarToggleButton = documentReference.getElementById(controlElementId.AVATAR_TOGGLE);
         const avatarMenuElement = documentReference.getElementById(controlElementId.AVATAR_MENU);

--- a/state.js
+++ b/state.js
@@ -142,6 +142,12 @@ class StateManager {
         return this.#stopButtonMode;
     }
 
+    /**
+     * Validates and stores the active avatar identifier.
+     * Falls back to the default avatar when the provided identifier is not recognized.
+     *
+     * @param {string} avatarId - Candidate avatar identifier selected by the user.
+     */
     setSelectedAvatar(avatarId) {
         const validatedAvatarIdentifier =
             typeof avatarId === "string" && ValidAvatarIdentifierSet.has(avatarId)


### PR DESCRIPTION
## Summary
- document avatar selection options and usage in the README
- add JSDoc blocks for the avatar selection helpers and state manager method
- create avatar asset documentation outlining licensing and contribution expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9f0936a2c8327818343dc042b232d