### PR TITLE
Enhance allergy selection card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,16 +242,31 @@
         main { flex: 1; display: grid; place-items: center; padding: 20px }
 
         .card {
+            --card-inset: clamp(16px, 2.8vw, 24px);
             width: min(900px, 92vw);
-            background: var(--card);
-            border-radius: 18px;
-            box-shadow: var(--shadow);
-            padding: 20px
+            position: relative;
+            z-index: 0;
+            isolation: isolate;
+            background: linear-gradient(145deg, #fff6f4 0%, #ffffff 100%);
+            border: 4px solid #000;
+            border-radius: 28px;
+            box-shadow: 0 20px 38px rgba(255, 77, 109, .18);
+            padding: clamp(28px, 4vw, 42px)
+        }
+
+        .card::before {
+            content: "";
+            position: absolute;
+            inset: var(--card-inset);
+            border: 3px dotted rgba(255, 77, 109, .6);
+            border-radius: calc(28px - (var(--card-inset) * .6));
+            pointer-events: none;
+            z-index: -1
         }
 
         .title { margin: 0 0 10px 0; font-size: clamp(22px, 3.4vw, 34px) }
         .muted { color: var(--muted) }
-        .actions { margin-top: 12px }
+        .actions { margin-top: clamp(18px, 2.6vw, 30px); padding-top: clamp(6px, 1.6vw, 14px) }
 
         /* Base buttons */
         .btn { border: 0; border-radius: 999px; padding: 12px 18px; font-weight: 800; cursor: pointer }


### PR DESCRIPTION
## Summary
- restyle the selection card with a bolder border, complementary gradient fill, and enhanced shadow to mirror the reveal card
- add an inset dotted pseudo-element and comfortable spacing to frame the card content without crowding actions

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68c9f8375b808327af1dd45f75595aa4