### PR TITLE
Adjust allergy card actions layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,11 @@
             border: 4px solid #000;
             border-radius: 28px;
             box-shadow: 0 20px 38px rgba(255, 77, 109, .18);
-            padding: clamp(28px, 4vw, 42px)
+            padding: clamp(28px, 4vw, 42px);
+            min-height: min(640px, 90vh);
+            display: flex;
+            flex-direction: column;
+            gap: clamp(18px, 3vw, 28px);
         }
 
         .card::before {
@@ -264,14 +268,51 @@
             z-index: -1
         }
 
+        .card__body {
+            display: flex;
+            flex-direction: column;
+            gap: clamp(16px, 2.6vw, 24px);
+            flex: 1 1 auto;
+        }
+
+        .card__body .grid { flex: 1 1 auto; }
+
         .title { margin: 0 0 10px 0; font-size: clamp(22px, 3.4vw, 34px) }
         .muted { color: var(--muted) }
         .actions { margin-top: clamp(18px, 2.6vw, 30px); padding-top: clamp(6px, 1.6vw, 14px) }
+
+        .card__actions {
+            margin-top: auto;
+            width: 100%;
+            padding: clamp(6px, 1.6vw, 14px) clamp(var(--card-inset), 4vw, 32px) clamp(var(--card-inset), 4vw, 32px);
+            display: flex;
+            flex-wrap: wrap;
+            align-items: flex-end;
+            justify-content: flex-end;
+            gap: clamp(12px, 3vw, 24px);
+        }
+
+        .card-actions__status {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-right: auto;
+        }
+
+        .card-actions__status .muted { margin: 0; }
 
         /* Base buttons */
         .btn { border: 0; border-radius: 999px; padding: 12px 18px; font-weight: 800; cursor: pointer }
         .btn.primary { background: var(--primary); color: var(--ink); box-shadow: var(--shadow) }
         .btn.danger { background: var(--danger); color: #fff; box-shadow: 4px 6px 0 #000; border: 4px solid #000 }
+
+        .btn.start-button {
+            padding: clamp(18px, 3.4vw, 26px) clamp(32px, 5.4vw, 58px);
+            font-size: clamp(20px, 3vw, 28px);
+            font-weight: 900;
+            inline-size: min(100%, clamp(220px, 40vw, 320px));
+            min-height: clamp(60px, 12vw, 88px);
+        }
 
         /* Unified center action button */
         .btn.action { color: #fff; border: 4px solid #000; box-shadow: 4px 6px 0 #000; font-weight: 900; }
@@ -387,14 +428,18 @@
 <!-- Allergy selection -->
 <main id="screen-allergy">
     <div class="card">
-        <h2 class="title">Pick your allergens</h2>
-        <p class="muted">Choose anything that might cause trouble. You can change this later.</p>
-        <div class="grid cols-2" id="allergy-list"></div>
-        <div class="actions">
-            <button class="btn primary" disabled id="start">Spin the Wheel</button>
+        <div class="card__body">
+            <h2 class="title">Pick your allergens</h2>
+            <p class="muted">Choose anything that might cause trouble. You can change this later.</p>
+            <div class="grid cols-2" id="allergy-list"></div>
         </div>
-        <p class="muted" id="loading">Loading data…</p>
-        <p class="muted" hidden id="load-error">Could not load data. Check JSON paths.</p>
+        <div class="actions card__actions">
+            <div class="card-actions__status">
+                <p class="muted" id="loading">Loading data…</p>
+                <p class="muted" hidden id="load-error">Could not load data. Check JSON paths.</p>
+            </div>
+            <button class="btn primary start-button" disabled id="start">Spin the Wheel</button>
+        </div>
     </div>
 </main>
 


### PR DESCRIPTION
## Summary
- anchor the allergy card action area to the lower-right corner of the card so it stays inside the dotted ridge
- wrap the card body and status messaging in new layout helpers to keep the start CTA pinned while content grows
- add a dedicated start button modifier that increases its footprint to match the mockup sizing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2f8e38308327855fc219db926acf