### PR TITLE
Add attention animation when no allergen is selected

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -51,7 +51,8 @@ export const ControlElementId = Object.freeze({
     GAME_OVER_SECTION: "gameover",
     RESTART_BUTTON: "restart",
     AVATAR_TOGGLE: "avatar-toggle",
-    AVATAR_MENU: "avatar-menu"
+    AVATAR_MENU: "avatar-menu",
+    ALLERGY_TITLE: "allergy-title"
 });
 
 const AvatarOptionClassName = "avatar-option";
@@ -65,6 +66,12 @@ export const AvatarClassName = Object.freeze({
 
 export const AvatarMenuClassName = Object.freeze({
     OPEN: AvatarMenuOpenClassName
+});
+
+const TitleAttentionClassName = "title--attention";
+
+export const TitleClassName = Object.freeze({
+    ATTENTION: TitleAttentionClassName
 });
 
 export const FirstCardElementId = Object.freeze({
@@ -111,7 +118,8 @@ export const BrowserEventName = Object.freeze({
     DOM_CONTENT_LOADED: "DOMContentLoaded",
     CLICK: "click",
     KEY_DOWN: "keydown",
-    CHANGE: "change"
+    CHANGE: "change",
+    ANIMATION_END: "animationend"
 });
 
 export const KeyboardKey = Object.freeze({

--- a/index.html
+++ b/index.html
@@ -278,6 +278,23 @@
         .card__body .grid { flex: 1 1 auto; }
 
         .title { margin: 0 0 10px 0; font-size: clamp(22px, 3.4vw, 34px) }
+
+        @keyframes title-attention {
+            0%,
+            100% { transform: scale(1); opacity: 1; }
+            30% { transform: scale(1.12); opacity: 1; }
+            50% { opacity: .25; }
+            70% { transform: scale(1.12); opacity: 1; }
+        }
+
+        .title--attention {
+            animation-name: title-attention;
+            animation-duration: 420ms;
+            animation-timing-function: ease-in-out;
+            animation-iteration-count: 3;
+            animation-direction: alternate;
+            animation-fill-mode: none;
+        }
         .muted { color: var(--muted) }
         .actions { margin-top: clamp(18px, 2.6vw, 30px); padding-top: clamp(6px, 1.6vw, 14px) }
 
@@ -429,7 +446,7 @@
 <main id="screen-allergy">
     <div class="card">
         <div class="card__body">
-            <h2 class="title">Pick your allergens</h2>
+            <h2 class="title" id="allergy-title">Pick your allergens</h2>
             <p class="muted">Choose anything that might cause trouble. You can change this later.</p>
             <div class="grid cols-2" id="allergy-list"></div>
         </div>

--- a/listeners.js
+++ b/listeners.js
@@ -4,7 +4,8 @@ import {
     KeyboardKey,
     AttributeBooleanValue,
     AvatarClassName,
-    AvatarMenuClassName
+    AvatarMenuClassName,
+    TitleClassName
 } from "./constants.js";
 
 const ListenerErrorMessage = {
@@ -23,8 +24,35 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     function wireStartButton({ onStartRequested }) {
         const startButton = documentReference.getElementById(controlElementId.START_BUTTON);
         if (!startButton) return;
+
+        const allergyTitleElement = documentReference.getElementById(controlElementId.ALLERGY_TITLE);
+        const attentionAnimationClassName = TitleClassName.ATTENTION;
+
+        if (allergyTitleElement && attentionAnimationClassName) {
+            const handleTitleAnimationEnd = () => {
+                allergyTitleElement.classList.remove(attentionAnimationClassName);
+            };
+            allergyTitleElement.addEventListener(
+                BrowserEventName.ANIMATION_END,
+                handleTitleAnimationEnd
+            );
+        }
+
         startButton.addEventListener(BrowserEventName.CLICK, () => {
-            if (!stateManager.hasSelectedAllergen()) return;
+            const hasSelectedAllergen = stateManager.hasSelectedAllergen();
+            if (!hasSelectedAllergen) {
+                if (allergyTitleElement && attentionAnimationClassName) {
+                    allergyTitleElement.classList.remove(attentionAnimationClassName);
+                    void allergyTitleElement.offsetWidth;
+                    allergyTitleElement.classList.add(attentionAnimationClassName);
+                }
+                return;
+            }
+
+            if (allergyTitleElement && attentionAnimationClassName) {
+                allergyTitleElement.classList.remove(attentionAnimationClassName);
+            }
+
             if (typeof onStartRequested === "function") {
                 onStartRequested();
             }


### PR DESCRIPTION
## Summary
- add an animated helper class for titles that blinks and scales when attention is needed
- wire the start button to animate the allergy title when pressed without a selection and restart the animation on each press
- stop the animation class once it finishes so valid spins show the normal title

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca31551334832791b4ea200c73ae06