### PR TITLE
Refine start button accessibility state

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import { showScreen, setWheelControlToStop, setWheelControlToStartGame } from ".
 import {
     ControlElementId,
     AttributeName,
+    AttributeBooleanValue,
     BrowserEventName,
     FirstCardElementId,
     ResultCardElementId,
@@ -54,7 +55,14 @@ const firstCardPresenter = new AllergenCard({
 
         const startButtonElement = document.getElementById(ControlElementId.START_BUTTON);
         if (startButtonElement) {
-            startButtonElement.disabled = false;
+            const blockedAttributeName = AttributeName.DATA_BLOCKED;
+            if (blockedAttributeName) {
+                startButtonElement.setAttribute(blockedAttributeName, AttributeBooleanValue.FALSE);
+            }
+            const ariaDisabledAttributeName = AttributeName.ARIA_DISABLED;
+            if (ariaDisabledAttributeName) {
+                startButtonElement.setAttribute(ariaDisabledAttributeName, AttributeBooleanValue.FALSE);
+            }
         }
 
         const badgeEntry = {

--- a/constants.js
+++ b/constants.js
@@ -103,10 +103,12 @@ export const HeartsElementId = Object.freeze({
 
 export const AttributeName = Object.freeze({
     ARIA_HIDDEN: "aria-hidden",
+    ARIA_LABEL: "aria-label",
+    ARIA_EXPANDED: "aria-expanded",
+    ARIA_DISABLED: "aria-disabled",
     DATA_SCREEN: "data-screen",
     DATA_COUNT: "data-count",
-    ARIA_LABEL: "aria-label",
-    ARIA_EXPANDED: "aria-expanded"
+    DATA_BLOCKED: "data-blocked"
 });
 
 export const AttributeBooleanValue = Object.freeze({

--- a/game.js
+++ b/game.js
@@ -379,12 +379,32 @@ export class GameController {
 
         this.#firstCardPresenter.renderAllergens(allergensCatalog);
 
-        const startButton = this.#documentReference.getElementById(this.#controlElementIdMap.START_BUTTON);
-        if (startButton) {
-            startButton.disabled = true;
-        }
+        this.#setStartButtonBlockedState(true);
         if (typeof this.#firstCardPresenter.updateBadges === "function") {
             this.#firstCardPresenter.updateBadges([]);
+        }
+    }
+
+    #setStartButtonBlockedState(shouldBlockStartButton) {
+        const startButtonElement = this.#documentReference.getElementById(this.#controlElementIdMap.START_BUTTON);
+        if (!startButtonElement) {
+            return;
+        }
+
+        const blockedAttributeName = this.#attributeNameMap.DATA_BLOCKED;
+        if (blockedAttributeName) {
+            startButtonElement.setAttribute(
+                blockedAttributeName,
+                shouldBlockStartButton ? AttributeBooleanValue.TRUE : AttributeBooleanValue.FALSE
+            );
+        }
+
+        const ariaDisabledAttributeName = this.#attributeNameMap.ARIA_DISABLED;
+        if (ariaDisabledAttributeName) {
+            startButtonElement.setAttribute(
+                ariaDisabledAttributeName,
+                shouldBlockStartButton ? AttributeBooleanValue.TRUE : AttributeBooleanValue.FALSE
+            );
         }
     }
 
@@ -721,10 +741,7 @@ export class GameController {
         if (this.#stateManager.resetWheelCandidates) {
             this.#stateManager.resetWheelCandidates();
         }
-        const startButton = this.#documentReference.getElementById(this.#controlElementIdMap.START_BUTTON);
-        if (startButton) {
-            startButton.disabled = true;
-        }
+        this.#setStartButtonBlockedState(true);
         if (typeof this.#firstCardPresenter.updateBadges === "function") {
             this.#firstCardPresenter.updateBadges([]);
         }

--- a/index.html
+++ b/index.html
@@ -331,6 +331,16 @@
             min-height: clamp(60px, 12vw, 88px);
         }
 
+        .start-button[data-blocked="true"] {
+            opacity: 0.55;
+            transform: none;
+        }
+
+        .start-button[data-blocked="true"]:hover,
+        .start-button[data-blocked="true"]:focus-visible {
+            transform: none;
+        }
+
         /* Unified center action button */
         .btn.action { color: #fff; border: 4px solid #000; box-shadow: 4px 6px 0 #000; font-weight: 900; }
         .btn.action.is-start { background: var(--success); }
@@ -455,7 +465,7 @@
                 <p class="muted" id="loading">Loading data…</p>
                 <p class="muted" hidden id="load-error">Could not load data. Check JSON paths.</p>
             </div>
-            <button class="btn primary start-button" disabled id="start">Spin the Wheel</button>
+            <button aria-disabled="true" class="btn primary start-button" data-blocked="true" id="start">Spin the Wheel</button>
         </div>
     </div>
 </main>

--- a/listeners.js
+++ b/listeners.js
@@ -27,6 +27,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
 
         const allergyTitleElement = documentReference.getElementById(controlElementId.ALLERGY_TITLE);
         const attentionAnimationClassName = TitleClassName.ATTENTION;
+        const blockedStateAttributeName = attributeName.DATA_BLOCKED;
 
         if (allergyTitleElement && attentionAnimationClassName) {
             const handleTitleAnimationEnd = () => {
@@ -46,6 +47,13 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
                     void allergyTitleElement.offsetWidth;
                     allergyTitleElement.classList.add(attentionAnimationClassName);
                 }
+                return;
+            }
+
+            const isStartButtonBlocked = blockedStateAttributeName
+                ? startButton.getAttribute(blockedStateAttributeName) === AttributeBooleanValue.TRUE
+                : false;
+            if (isStartButtonBlocked) {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- replace the start button's `disabled` flag with a `data-blocked` attribute and ARIA state, including styles for the blocked appearance
- update the game initialization, reset flow, and allergen selection handler to toggle the new blocked indicators instead of `button.disabled`
- let the start listener respect the new blocked attribute while still using the state manager to guard spin attempts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca3640b2fc8327baf0757755c1aefe