### PR TITLE
Add helper for start button blocked state

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,29 @@ const board = new Board({
     normalizationEngine: new NormalizationEngine([])
 });
 
+const setDocumentStartButtonBlockedState = (shouldBlockStartButton) => {
+    const startButtonElement = document.getElementById(ControlElementId.START_BUTTON);
+    if (!startButtonElement) {
+        return;
+    }
+
+    const blockedAttributeName = AttributeName.DATA_BLOCKED;
+    if (blockedAttributeName) {
+        startButtonElement.setAttribute(
+            blockedAttributeName,
+            shouldBlockStartButton ? AttributeBooleanValue.TRUE : AttributeBooleanValue.FALSE
+        );
+    }
+
+    const ariaDisabledAttributeName = AttributeName.ARIA_DISABLED;
+    if (ariaDisabledAttributeName) {
+        startButtonElement.setAttribute(
+            ariaDisabledAttributeName,
+            shouldBlockStartButton ? AttributeBooleanValue.TRUE : AttributeBooleanValue.FALSE
+        );
+    }
+};
+
 const firstCardPresenter = new AllergenCard({
     listContainerElement: document.getElementById(FirstCardElementId.LIST_CONTAINER),
     badgeContainerElement: document.getElementById(FirstCardElementId.BADGE_CONTAINER),
@@ -53,17 +76,7 @@ const firstCardPresenter = new AllergenCard({
             label: selectedLabel
         });
 
-        const startButtonElement = document.getElementById(ControlElementId.START_BUTTON);
-        if (startButtonElement) {
-            const blockedAttributeName = AttributeName.DATA_BLOCKED;
-            if (blockedAttributeName) {
-                startButtonElement.setAttribute(blockedAttributeName, AttributeBooleanValue.FALSE);
-            }
-            const ariaDisabledAttributeName = AttributeName.ARIA_DISABLED;
-            if (ariaDisabledAttributeName) {
-                startButtonElement.setAttribute(ariaDisabledAttributeName, AttributeBooleanValue.FALSE);
-            }
-        }
+        setDocumentStartButtonBlockedState(false);
 
         const badgeEntry = {
             label: selectedLabel,

--- a/index.html
+++ b/index.html
@@ -332,13 +332,18 @@
         }
 
         .start-button[data-blocked="true"] {
-            opacity: 0.55;
+            cursor: pointer;
+            background: linear-gradient(145deg, #ffd6e1 0%, #ffb6c9 100%);
+            color: rgba(255, 255, 255, 0.85);
+            box-shadow: 0 10px 22px rgba(0, 0, 0, .1);
+            opacity: 0.75;
             transform: none;
         }
 
         .start-button[data-blocked="true"]:hover,
         .start-button[data-blocked="true"]:focus-visible {
             transform: none;
+            box-shadow: 0 10px 22px rgba(0, 0, 0, .1);
         }
 
         /* Unified center action button */


### PR DESCRIPTION
## Summary
- style the start button’s blocked state so it reads as unavailable while retaining the pointer cursor
- add a helper that toggles the start button’s aria-disabled and data-blocked attributes when an allergen is chosen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca39cae75c8327864127348e48c49c