### PR TITLE
Add dinosaur avatars and extend avatar selection coverage

### DIFF
--- a/app.js
+++ b/app.js
@@ -90,7 +90,9 @@ const avatarResourceMap = new Map([
     [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
     [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
     [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
-    [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
+    [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY],
+    [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX],
+    [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
 ]);
 
 const revealCardPresenter = new ResultCard({

--- a/assets/avatars/triceratops.svg
+++ b/assets/avatars/triceratops.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="60" fill="#e0f0ff"/>
+  <path d="M24 74c0-18 14-40 36-46 20-4 40 4 52 18-4 18-16 34-32 40-18 6-40 4-56-12z" fill="#6fa8dc" stroke="#2b5d8f" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M44 58c-6-12-18-18-26-16 0 10 4 20 12 28" fill="#8cb9e3" stroke="#2b5d8f" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="70" cy="60" r="6" fill="#1b1b1b"/>
+  <path d="M54 80c8 8 18 8 26 0" fill="none" stroke="#1b1b1b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M44 68l-8 12" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round"/>
+  <path d="M52 64l-6 14" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round"/>
+  <path d="M62 60l-2 14" fill="none" stroke="#ffffff" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/assets/avatars/tyrannosaurus-rex.svg
+++ b/assets/avatars/tyrannosaurus-rex.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="60" fill="#d6f5d6"/>
+  <path d="M28 68c0-18 16-36 40-36 12 0 24 4 32 10-6 20-22 40-40 40-8 0-20-2-32-14z" fill="#3cb371" stroke="#1f5135" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M68 42c6-6 18-10 26-6 4 6 6 12 6 20-6-6-16-8-24-6" fill="#2e8b57" stroke="#1f5135" stroke-width="4" stroke-linejoin="round"/>
+  <circle cx="74" cy="50" r="4" fill="#1b1b1b"/>
+  <path d="M62 64c6 6 16 6 22 0" fill="none" stroke="#1b1b1b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M44 78c-4 8-2 14 4 20" fill="none" stroke="#1f5135" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/constants.js
+++ b/constants.js
@@ -13,6 +13,8 @@ const AvatarIdentifierSunnyGirl = "avatar-sunny-girl";
 const AvatarIdentifierCuriousGirl = "avatar-curious-girl";
 const AvatarIdentifierAdventurousBoy = "avatar-adventurous-boy";
 const AvatarIdentifierCreativeBoy = "avatar-creative-boy";
+const AvatarIdentifierTyrannosaurusRex = "avatar-tyrannosaurus-rex";
+const AvatarIdentifierTriceratops = "avatar-triceratops";
 
 export const MODE_STOP = WheelControlModeStringStop;
 export const MODE_START = WheelControlModeStringStart;
@@ -27,19 +29,25 @@ export const AvatarId = Object.freeze({
     SUNNY_GIRL: AvatarIdentifierSunnyGirl,
     CURIOUS_GIRL: AvatarIdentifierCuriousGirl,
     ADVENTUROUS_BOY: AvatarIdentifierAdventurousBoy,
-    CREATIVE_BOY: AvatarIdentifierCreativeBoy
+    CREATIVE_BOY: AvatarIdentifierCreativeBoy,
+    TYRANNOSAURUS_REX: AvatarIdentifierTyrannosaurusRex,
+    TRICERATOPS: AvatarIdentifierTriceratops
 });
 
 const AvatarAssetPathSunnyGirl = "assets/avatars/sunny-girl.svg";
 const AvatarAssetPathCuriousGirl = "assets/avatars/curious-girl.svg";
 const AvatarAssetPathAdventurousBoy = "assets/avatars/adventurous-boy.svg";
 const AvatarAssetPathCreativeBoy = "assets/avatars/creative-boy.svg";
+const AvatarAssetPathTyrannosaurusRex = "assets/avatars/tyrannosaurus-rex.svg";
+const AvatarAssetPathTriceratops = "assets/avatars/triceratops.svg";
 
 export const AvatarAssetPath = Object.freeze({
     SUNNY_GIRL: AvatarAssetPathSunnyGirl,
     CURIOUS_GIRL: AvatarAssetPathCuriousGirl,
     ADVENTUROUS_BOY: AvatarAssetPathAdventurousBoy,
-    CREATIVE_BOY: AvatarAssetPathCreativeBoy
+    CREATIVE_BOY: AvatarAssetPathCreativeBoy,
+    TYRANNOSAURUS_REX: AvatarAssetPathTyrannosaurusRex,
+    TRICERATOPS: AvatarAssetPathTriceratops
 });
 
 export const ControlElementId = Object.freeze({

--- a/index.html
+++ b/index.html
@@ -466,6 +466,14 @@
                     <span class="visually-hidden">Creative boy</span>
                     <img alt="Creative boy avatar option" class="avatar-image" src="assets/avatars/creative-boy.svg"/>
                 </button>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-tyrannosaurus-rex" type="button">
+                    <span class="visually-hidden">Tyrannosaurus rex</span>
+                    <img alt="Tyrannosaurus rex avatar option" class="avatar-image" src="assets/avatars/tyrannosaurus-rex.svg"/>
+                </button>
+                <button class="avatar-button avatar-option" data-avatar-id="avatar-triceratops" type="button">
+                    <span class="visually-hidden">Triceratops</span>
+                    <img alt="Triceratops avatar option" class="avatar-image" src="assets/avatars/triceratops.svg"/>
+                </button>
             </div>
         </div>
         <h1>Allergy Wheel</h1>

--- a/tests/integration/avatarSelection.integration.test.js
+++ b/tests/integration/avatarSelection.integration.test.js
@@ -54,17 +54,29 @@ const AvatarResourceEntries = Object.freeze([
   [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
   [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
   [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
-  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
+  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY],
+  [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX],
+  [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
 ]);
 
 const AvatarSelectionTestDescription = Object.freeze({
   CREATIVE: "selecting the creative boy avatar renders it on the result card",
-  CURIOUS: "selecting the curious girl avatar renders it on the result card"
+  CURIOUS: "selecting the curious girl avatar renders it on the result card",
+  TYRANNOSAURUS: "selecting the tyrannosaurus rex avatar renders it on the result card",
+  TRICERATOPS: "selecting the triceratops avatar renders it on the result card"
 });
 
 const AvatarSelectionTestCases = [
   { description: AvatarSelectionTestDescription.CREATIVE, chosenAvatarId: AvatarId.CREATIVE_BOY },
-  { description: AvatarSelectionTestDescription.CURIOUS, chosenAvatarId: AvatarId.CURIOUS_GIRL }
+  { description: AvatarSelectionTestDescription.CURIOUS, chosenAvatarId: AvatarId.CURIOUS_GIRL },
+  {
+    description: AvatarSelectionTestDescription.TYRANNOSAURUS,
+    chosenAvatarId: AvatarId.TYRANNOSAURUS_REX
+  },
+  {
+    description: AvatarSelectionTestDescription.TRICERATOPS,
+    chosenAvatarId: AvatarId.TRICERATOPS
+  }
 ];
 
 afterEach(() => {

--- a/tests/integration/avatarSelection.test.js
+++ b/tests/integration/avatarSelection.test.js
@@ -61,17 +61,29 @@ const AvatarResourceEntries = Object.freeze([
   [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
   [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
   [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
-  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
+  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY],
+  [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX],
+  [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
 ]);
 
 const AvatarSelectionScenarioDescription = Object.freeze({
-  CREATIVE_PERSISTENCE: "selecting the creative boy avatar persists across rounds"
+  CREATIVE_PERSISTENCE: "selecting the creative boy avatar persists across rounds",
+  TYRANNOSAURUS_PERSISTENCE: "selecting the tyrannosaurus rex avatar persists across rounds",
+  TRICERATOPS_PERSISTENCE: "selecting the triceratops avatar persists across rounds"
 });
 
 const AvatarSelectionScenarios = [
   {
     description: AvatarSelectionScenarioDescription.CREATIVE_PERSISTENCE,
     chosenAvatarId: AvatarId.CREATIVE_BOY
+  },
+  {
+    description: AvatarSelectionScenarioDescription.TYRANNOSAURUS_PERSISTENCE,
+    chosenAvatarId: AvatarId.TYRANNOSAURUS_REX
+  },
+  {
+    description: AvatarSelectionScenarioDescription.TRICERATOPS_PERSISTENCE,
+    chosenAvatarId: AvatarId.TRICERATOPS
   }
 ];
 

--- a/tests/unit/resultCard.test.js
+++ b/tests/unit/resultCard.test.js
@@ -24,8 +24,13 @@ const DishDetail = Object.freeze({
 const TestDescription = Object.freeze({
   RENDER_INLINE: "renders inline SVG markup for the selected avatar when allergen is present",
   RENDER_IMAGE_PATH: "renders <image> element for avatar resource paths when allergen is present",
+  RENDER_IMAGE_PATH_TYRANNOSAURUS:
+    "renders <image> element for the tyrannosaurus rex avatar resource when allergen is present",
   UPDATE_INVALID_FALLBACK: "falls back to default avatar when provided identifier is invalid",
-  UPDATE_PATH_IMMEDIATE_RENDER: "renders avatar image immediately when avatar selection changes"
+  UPDATE_PATH_IMMEDIATE_RENDER: "renders avatar image immediately when avatar selection changes",
+  UPDATE_PATH_TYRANNOSAURUS:
+    "renders the tyrannosaurus rex avatar image when avatar selection changes",
+  UPDATE_PATH_TRICERATOPS: "renders the triceratops avatar image when avatar selection changes"
 });
 
 const AvatarResourceType = Object.freeze({
@@ -35,6 +40,10 @@ const AvatarResourceType = Object.freeze({
 
 const SvgElementSelector = Object.freeze({
   IMAGE: "image"
+});
+
+const SvgAttributeName = Object.freeze({
+  HREF: "href"
 });
 
 const InvalidAvatarIdentifier = Object.freeze({
@@ -89,6 +98,14 @@ function createResultCardTestHarness({ avatarMapEntries }) {
   };
 }
 
+function createPathExpectation(expectedResourcePath) {
+  return (faceSvgElement) => {
+    const imageElement = faceSvgElement.querySelector(SvgElementSelector.IMAGE);
+    expect(imageElement).not.toBeNull();
+    expect(imageElement.getAttribute(SvgAttributeName.HREF)).toBe(expectedResourcePath);
+  };
+}
+
 const RevealCardAvatarRenderingCases = [
   {
     description: TestDescription.RENDER_INLINE,
@@ -109,6 +126,16 @@ const RevealCardAvatarRenderingCases = [
     selectedAvatarId: AvatarId.CREATIVE_BOY,
     avatarResourceType: AvatarResourceType.PATH,
     expectedMarkup: AvatarAssetPath.CREATIVE_BOY
+  },
+  {
+    description: TestDescription.RENDER_IMAGE_PATH_TYRANNOSAURUS,
+    avatarMapEntries: [
+      [AvatarId.SUNNY_GIRL, AvatarMarkup.SUNNY],
+      [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX]
+    ],
+    selectedAvatarId: AvatarId.TYRANNOSAURUS_REX,
+    avatarResourceType: AvatarResourceType.PATH,
+    expectedMarkup: AvatarAssetPath.TYRANNOSAURUS_REX
   }
 ];
 
@@ -137,7 +164,7 @@ describe("ResultCard avatar rendering", () => {
       } else {
         const imageElement = faceSvgElement.querySelector(SvgElementSelector.IMAGE);
         expect(imageElement).not.toBeNull();
-        const hrefAttribute = imageElement.getAttribute("href");
+        const hrefAttribute = imageElement.getAttribute(SvgAttributeName.HREF);
         expect(hrefAttribute).toBe(expectedMarkup);
       }
     }
@@ -154,11 +181,29 @@ const UpdateAvatarSelectionCases = [
       [AvatarId.SUNNY_GIRL, AvatarMarkup.SUNNY],
       [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY]
     ],
-    expectation: (faceSvgElement) => {
-      const imageElement = faceSvgElement.querySelector(SvgElementSelector.IMAGE);
-      expect(imageElement).not.toBeNull();
-      expect(imageElement.getAttribute("href")).toBe(AvatarAssetPath.CREATIVE_BOY);
-    }
+    expectation: createPathExpectation(AvatarAssetPath.CREATIVE_BOY)
+  },
+  {
+    description: TestDescription.UPDATE_PATH_TYRANNOSAURUS,
+    avatarIdentifierCandidate: AvatarId.TYRANNOSAURUS_REX,
+    expectedSelectedAvatarId: AvatarId.TYRANNOSAURUS_REX,
+    expectedHasRenderableAvatar: true,
+    avatarMapEntries: [
+      [AvatarId.SUNNY_GIRL, AvatarMarkup.SUNNY],
+      [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX]
+    ],
+    expectation: createPathExpectation(AvatarAssetPath.TYRANNOSAURUS_REX)
+  },
+  {
+    description: TestDescription.UPDATE_PATH_TRICERATOPS,
+    avatarIdentifierCandidate: AvatarId.TRICERATOPS,
+    expectedSelectedAvatarId: AvatarId.TRICERATOPS,
+    expectedHasRenderableAvatar: true,
+    avatarMapEntries: [
+      [AvatarId.SUNNY_GIRL, AvatarMarkup.SUNNY],
+      [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
+    ],
+    expectation: createPathExpectation(AvatarAssetPath.TRICERATOPS)
   },
   {
     description: TestDescription.UPDATE_INVALID_FALLBACK,

--- a/tests/unit/stateManager.test.js
+++ b/tests/unit/stateManager.test.js
@@ -40,6 +40,8 @@ const StateTestDescription = Object.freeze({
   STOP_BUTTON_SWITCH: "switches between start and stop modes",
   AVATAR_DEFAULT: "provides the default avatar when initialized",
   AVATAR_VALID_SELECTION: "stores a provided valid avatar identifier",
+  AVATAR_TYRANNOSAURUS_SELECTION: "stores the tyrannosaurus rex avatar identifier when selected",
+  AVATAR_TRICERATOPS_SELECTION: "stores the triceratops avatar identifier when selected",
   AVATAR_INVALID_UNKNOWN: "falls back to the default avatar when given an unknown identifier",
   AVATAR_INVALID_NON_STRING: "falls back to the default avatar when given a non-string identifier",
   AVATAR_RESET_ON_INITIALIZE: "reinitialize restores the default avatar"
@@ -147,6 +149,18 @@ const AvatarSelectionCases = [
     description: StateTestDescription.AVATAR_VALID_SELECTION,
     avatarIdentifier: AvatarId.CURIOUS_GIRL,
     expectedStoredIdentifier: AvatarId.CURIOUS_GIRL,
+    expectedHasSelection: true
+  },
+  {
+    description: StateTestDescription.AVATAR_TYRANNOSAURUS_SELECTION,
+    avatarIdentifier: AvatarId.TYRANNOSAURUS_REX,
+    expectedStoredIdentifier: AvatarId.TYRANNOSAURUS_REX,
+    expectedHasSelection: true
+  },
+  {
+    description: StateTestDescription.AVATAR_TRICERATOPS_SELECTION,
+    avatarIdentifier: AvatarId.TRICERATOPS,
+    expectedStoredIdentifier: AvatarId.TRICERATOPS,
     expectedHasSelection: true
   },
   {


### PR DESCRIPTION
## Summary
- define new Tyrannosaurus rex and Triceratops avatar identifiers and asset paths and expose them via AvatarId/AvatarAssetPath
- provide dinosaur avatar assets, surface them in the avatar menu, and wire the runtime map to load their resources
- extend integration and unit coverage to verify selection, rendering, and persistence for the new avatars

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca3eecfff88327a8465c60bdb6109f