### PR TITLE
Restore allergen chip styling to previous design

### DIFF
--- a/firstCard.js
+++ b/firstCard.js
@@ -3,6 +3,8 @@ import { BrowserEventName, ControlElementId } from "./constants.js";
 
 const ElementClassName = Object.freeze({
     CHIP: "chip",
+    CHIP_SELECTED: "chip--selected",
+    CHIP_RADIO: "chip__radio",
     BADGE: "badge",
     EMOJI_LARGE: "emoji-large"
 });
@@ -81,8 +83,10 @@ export class AllergenCard {
             radioElement.type = RadioInputConfiguration.TYPE;
             radioElement.name = RadioInputConfiguration.NAME;
             radioElement.value = allergenToken;
+            radioElement.className = ElementClassName.CHIP_RADIO;
 
             radioElement.addEventListener(BrowserEventName.CHANGE, () => {
+                this.#setSelectedChip(labelElement);
                 this.#handleAllergenSelection({
                     token: allergenToken,
                     label: allergenLabel,
@@ -115,7 +119,14 @@ export class AllergenCard {
 
         this.#badgeContainerElement.textContent = TextContent.EMPTY;
 
-        for (const allergenEntry of allergenEntries || []) {
+        const normalizedEntries = Array.isArray(allergenEntries) ? allergenEntries : [];
+
+        if (normalizedEntries.length === 0) {
+            this.#clearChipSelection();
+            return;
+        }
+
+        for (const allergenEntry of normalizedEntries) {
             const labelText = typeof allergenEntry === ValueType.STRING
                 ? allergenEntry
                 : (allergenEntry && allergenEntry.label) || TextContent.EMPTY;
@@ -138,6 +149,40 @@ export class AllergenCard {
             }
 
             this.#badgeContainerElement.appendChild(badgeElement);
+        }
+    }
+
+    #setSelectedChip(selectedChipElement) {
+        if (!this.#listContainerElement || !selectedChipElement) {
+            return;
+        }
+
+        const chipElements = this.#listContainerElement
+            .querySelectorAll(`.${ElementClassName.CHIP}`);
+
+        for (const chipElement of chipElements) {
+            const shouldMarkSelected = chipElement === selectedChipElement;
+            chipElement.classList.toggle(ElementClassName.CHIP_SELECTED, shouldMarkSelected);
+        }
+    }
+
+    #clearChipSelection() {
+        if (!this.#listContainerElement) {
+            return;
+        }
+
+        const chipElements = this.#listContainerElement
+            .querySelectorAll(`.${ElementClassName.CHIP}`);
+
+        for (const chipElement of chipElements) {
+            chipElement.classList.remove(ElementClassName.CHIP_SELECTED);
+            const inputElements = chipElement.getElementsByTagName(ElementTagName.INPUT);
+            if (inputElements && inputElements.length > 0) {
+                const radioInputElement = inputElements[0];
+                if (radioInputElement && radioInputElement.type === RadioInputConfiguration.TYPE) {
+                    radioInputElement.checked = false;
+                }
+            }
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,12 @@
             --success: #2ecc71;
             --card: #fff;
             --muted: #666;
-            --shadow: 0 12px 30px rgba(0, 0, 0, .15)
+            --shadow: 0 12px 30px rgba(0, 0, 0, .15);
+            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
+            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
+            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
+            --start-button-shadow: 4px 6px 0 #000;
+            --start-button-hover-shadow: 5px 7px 0 #000
         }
 
         html, body { height: 100% }
@@ -327,26 +332,41 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            padding: clamp(20px, 3.6vw, 28px) clamp(32px, 5.8vw, 64px);
-            font-size: clamp(22px, 3.4vw, 30px);
+            padding: clamp(20px, 3.2vw, 28px) clamp(32px, 5vw, 56px);
+            font-size: clamp(22px, 3vw, 28px);
             font-weight: 900;
             inline-size: 100%;
-            min-height: clamp(68px, 12vw, 96px);
+            max-inline-size: 280px;
+            min-height: clamp(72px, 12vw, 100px);
+            background: var(--start-button-bg);
+            color: var(--ink);
+            border: 4px solid #000;
+            box-shadow: var(--start-button-shadow);
+            transition: background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+        }
+
+        .btn.start-button:hover,
+        .btn.start-button:focus-visible {
+            background: var(--start-button-hover-bg);
+            box-shadow: var(--start-button-hover-shadow);
+            transform: translateY(-2px);
+            outline: none;
         }
 
         .start-button[data-blocked="true"] {
             cursor: pointer;
-            background: linear-gradient(145deg, #ffd6e1 0%, #ffb6c9 100%);
+            background: var(--start-button-disabled-bg);
             color: rgba(255, 255, 255, 0.85);
-            box-shadow: 0 10px 22px rgba(0, 0, 0, .1);
-            opacity: 0.75;
+            box-shadow: var(--start-button-shadow);
+            opacity: 0.82;
             transform: none;
         }
 
         .start-button[data-blocked="true"]:hover,
         .start-button[data-blocked="true"]:focus-visible {
+            background: var(--start-button-disabled-bg);
+            box-shadow: var(--start-button-shadow);
             transform: none;
-            box-shadow: 0 10px 22px rgba(0, 0, 0, .1);
         }
 
         /* Unified center action button */
@@ -363,41 +383,40 @@
             padding-block: clamp(8px, 2vw, 16px);
         }
 
-        .allergen-grid .chip {
-            inline-size: 100%;
-        }
+        .allergen-grid .chip { inline-size: 100%; }
 
         .allergen-grid .start-button {
-            grid-column: -2 / -1;
+            grid-column: -1;
             align-self: end;
-            justify-self: stretch;
-            margin-block-start: clamp(8px, 2vw, 16px);
+            justify-self: end;
+            margin: 0;
+        }
+
+        @media (max-width: 640px) {
+            .allergen-grid .start-button {
+                justify-self: stretch;
+            }
+            .btn.start-button {
+                max-inline-size: none;
+            }
         }
 
         .chip {
-            display: flex; align-items: center; gap: 10px;
-            padding: 12px 14px; border-radius: 999px;
-            background: #fff7c8; border: 2px solid #000; box-shadow: 2px 2px 0 #000;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 12px 14px;
+            border-radius: 999px;
+            background: #fff7c8;
+            border: 2px solid #000;
+            box-shadow: 2px 2px 0 #000;
             cursor: pointer;
-
-            transition: transform 160ms ease, box-shadow 160ms ease;
-
-            /* NEW: kid-friendly font for allergen names */
             font-family: "Fredoka One", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
             font-weight: 900;
             letter-spacing: .2px;
             font-size: clamp(16px, 1.6vw, 20px);
-            cursor: pointer;
             transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
         }
-        .chip:hover,
-        .chip:focus-visible {
-            transform: translateY(-1px);
-            box-shadow: 3px 3px 0 #000;
-            outline: none;
-        }
-        .chip input { width: 20px; height: 20px }
-        .chip .emoji-large { margin-left: auto; }
 
         .chip:hover,
         .chip:focus-visible {
@@ -405,6 +424,21 @@
             box-shadow: 3px 3px 0 #000;
             transform: translateY(-1px);
             outline: none;
+        }
+
+        .chip__radio {
+            width: 20px;
+            height: 20px;
+            flex-shrink: 0;
+            accent-color: var(--primary);
+        }
+
+        .chip .emoji-large { margin-left: auto; }
+
+        .chip--selected {
+            background: #fff1a1;
+            box-shadow: 3px 3px 0 #000;
+            transform: translateY(-1px);
         }
 
         /* Exclusive screens */

--- a/tests/unit/allergenCard.test.js
+++ b/tests/unit/allergenCard.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { AllergenCard } from "../../firstCard.js";
+import { BrowserEventName, ControlElementId, FirstCardElementId } from "../../constants.js";
+
+const CssClassName = Object.freeze({
+  CHIP: "chip",
+  CHIP_SELECTED: "chip--selected",
+});
+
+const HtmlTagName = Object.freeze({
+  INPUT: "input",
+});
+
+const SampleAllergens = Object.freeze([
+  { token: "peanuts", label: "Peanuts", emoji: "🥜" },
+  { token: "egg", label: "Egg", emoji: "🥚" },
+  { token: "fish", label: "Fish", emoji: "🐟" },
+]);
+
+const SelectionScenarios = SampleAllergens.map((allergen, index) => ({
+  description: `selecting ${allergen.label}`,
+  selectedIndex: index,
+}));
+
+const ResetScenarioTable = [{ description: "clearing selection state" }];
+
+describe("AllergenCard selection styling", () => {
+  let listContainerElement;
+  let badgeContainerElement;
+  let onSelectionSpy;
+  let cardPresenter;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="${FirstCardElementId.LIST_CONTAINER}">
+        <button id="${ControlElementId.START_BUTTON}"></button>
+      </div>
+      <div id="${FirstCardElementId.BADGE_CONTAINER}"></div>
+    `;
+
+    listContainerElement = document.getElementById(FirstCardElementId.LIST_CONTAINER);
+    badgeContainerElement = document.getElementById(FirstCardElementId.BADGE_CONTAINER);
+    onSelectionSpy = jest.fn();
+
+    cardPresenter = new AllergenCard({
+      listContainerElement,
+      badgeContainerElement,
+      onAllergenSelected: onSelectionSpy,
+    });
+
+    cardPresenter.renderAllergens(SampleAllergens);
+  });
+
+  it.each(SelectionScenarios)("applies selection class when %s", ({ selectedIndex }) => {
+    const radioInputs = listContainerElement.getElementsByTagName(HtmlTagName.INPUT);
+    const selectedRadio = radioInputs[selectedIndex];
+    selectedRadio.checked = true;
+    selectedRadio.dispatchEvent(new Event(BrowserEventName.CHANGE, { bubbles: true }));
+
+    const chipElements = Array.from(
+      listContainerElement.getElementsByClassName(CssClassName.CHIP),
+    );
+
+    chipElements.forEach((chipElement, chipIndex) => {
+      const hasSelectionClass = chipElement.classList.contains(CssClassName.CHIP_SELECTED);
+      expect(hasSelectionClass).toBe(chipIndex === selectedIndex);
+    });
+
+    const expectedSelection = SampleAllergens[selectedIndex];
+    expect(onSelectionSpy).toHaveBeenCalledWith({
+      token: expectedSelection.token,
+      label: expectedSelection.label,
+      emoji: expectedSelection.emoji,
+    });
+  });
+
+  it.each(ResetScenarioTable)("removes styling when %s", () => {
+    const radioInputs = listContainerElement.getElementsByTagName(HtmlTagName.INPUT);
+    const firstRadio = radioInputs[0];
+    firstRadio.checked = true;
+    firstRadio.dispatchEvent(new Event(BrowserEventName.CHANGE, { bubbles: true }));
+
+    cardPresenter.updateBadges([]);
+
+    const chipElements = Array.from(
+      listContainerElement.getElementsByClassName(CssClassName.CHIP),
+    );
+
+    chipElements.forEach((chipElement) => {
+      expect(chipElement.classList.contains(CssClassName.CHIP_SELECTED)).toBe(false);
+      const radioElement = chipElement.getElementsByTagName(HtmlTagName.INPUT)[0];
+      expect(radioElement.checked).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- revert the allergen grid and chip presentation to the earlier spacing and pill visuals
- simplify the chip radio styling while keeping the selected state aligned with the prior highlight

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68ca3fcc7d4483279cd26eada7833b5a