### PR TITLE
Add dinosaur avatar coverage to selection and result card tests

### DIFF
--- a/tests/integration/avatarSelection.integration.test.js
+++ b/tests/integration/avatarSelection.integration.test.js
@@ -50,15 +50,6 @@ const DishDescriptor = Object.freeze({
   HAZARDOUS_INGREDIENT: "peanut"
 });
 
-const AvatarResourceEntries = Object.freeze([
-  [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
-  [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
-  [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
-  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY],
-  [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX],
-  [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
-]);
-
 const AvatarSelectionTestDescription = Object.freeze({
   CREATIVE: "selecting the creative boy avatar renders it on the result card",
   CURIOUS: "selecting the curious girl avatar renders it on the result card",
@@ -66,18 +57,62 @@ const AvatarSelectionTestDescription = Object.freeze({
   TRICERATOPS: "selecting the triceratops avatar renders it on the result card"
 });
 
-const AvatarSelectionTestCases = [
-  { description: AvatarSelectionTestDescription.CREATIVE, chosenAvatarId: AvatarId.CREATIVE_BOY },
-  { description: AvatarSelectionTestDescription.CURIOUS, chosenAvatarId: AvatarId.CURIOUS_GIRL },
-  {
-    description: AvatarSelectionTestDescription.TYRANNOSAURUS,
-    chosenAvatarId: AvatarId.TYRANNOSAURUS_REX
-  },
-  {
-    description: AvatarSelectionTestDescription.TRICERATOPS,
-    chosenAvatarId: AvatarId.TRICERATOPS
+const DinosaurAvatarDescriptors = Object.freeze([
+  Object.freeze({
+    avatarIdentifier: AvatarId.TYRANNOSAURUS_REX,
+    avatarResourcePath: AvatarAssetPath.TYRANNOSAURUS_REX,
+    selectionDescription: AvatarSelectionTestDescription.TYRANNOSAURUS
+  }),
+  Object.freeze({
+    avatarIdentifier: AvatarId.TRICERATOPS,
+    avatarResourcePath: AvatarAssetPath.TRICERATOPS,
+    selectionDescription: AvatarSelectionTestDescription.TRICERATOPS
+  })
+]);
+
+const AvatarResourceEntries = (() => {
+  const baseEntries = [
+    Object.freeze([AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL]),
+    Object.freeze([AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL]),
+    Object.freeze([AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY]),
+    Object.freeze([AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY])
+  ];
+
+  for (const dinosaurAvatarDescriptor of DinosaurAvatarDescriptors) {
+    baseEntries.push(
+      Object.freeze([
+        dinosaurAvatarDescriptor.avatarIdentifier,
+        dinosaurAvatarDescriptor.avatarResourcePath
+      ])
+    );
   }
-];
+
+  return Object.freeze(baseEntries);
+})();
+
+const AvatarSelectionTestCases = (() => {
+  const baseTestCases = [
+    Object.freeze({
+      description: AvatarSelectionTestDescription.CREATIVE,
+      chosenAvatarId: AvatarId.CREATIVE_BOY
+    }),
+    Object.freeze({
+      description: AvatarSelectionTestDescription.CURIOUS,
+      chosenAvatarId: AvatarId.CURIOUS_GIRL
+    })
+  ];
+
+  for (const dinosaurAvatarDescriptor of DinosaurAvatarDescriptors) {
+    baseTestCases.push(
+      Object.freeze({
+        description: dinosaurAvatarDescriptor.selectionDescription,
+        chosenAvatarId: dinosaurAvatarDescriptor.avatarIdentifier
+      })
+    );
+  }
+
+  return Object.freeze(baseTestCases);
+})();
 
 afterEach(() => {
   document.body.innerHTML = EmptyStringValue;

--- a/tests/integration/avatarSelection.test.js
+++ b/tests/integration/avatarSelection.test.js
@@ -57,35 +57,64 @@ const DishDescriptor = Object.freeze({
   }
 });
 
-const AvatarResourceEntries = Object.freeze([
-  [AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL],
-  [AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL],
-  [AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY],
-  [AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY],
-  [AvatarId.TYRANNOSAURUS_REX, AvatarAssetPath.TYRANNOSAURUS_REX],
-  [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
-]);
-
 const AvatarSelectionScenarioDescription = Object.freeze({
   CREATIVE_PERSISTENCE: "selecting the creative boy avatar persists across rounds",
   TYRANNOSAURUS_PERSISTENCE: "selecting the tyrannosaurus rex avatar persists across rounds",
   TRICERATOPS_PERSISTENCE: "selecting the triceratops avatar persists across rounds"
 });
 
-const AvatarSelectionScenarios = [
-  {
-    description: AvatarSelectionScenarioDescription.CREATIVE_PERSISTENCE,
-    chosenAvatarId: AvatarId.CREATIVE_BOY
-  },
-  {
-    description: AvatarSelectionScenarioDescription.TYRANNOSAURUS_PERSISTENCE,
-    chosenAvatarId: AvatarId.TYRANNOSAURUS_REX
-  },
-  {
-    description: AvatarSelectionScenarioDescription.TRICERATOPS_PERSISTENCE,
-    chosenAvatarId: AvatarId.TRICERATOPS
+const DinosaurAvatarDescriptors = Object.freeze([
+  Object.freeze({
+    avatarIdentifier: AvatarId.TYRANNOSAURUS_REX,
+    avatarResourcePath: AvatarAssetPath.TYRANNOSAURUS_REX,
+    persistenceDescription: AvatarSelectionScenarioDescription.TYRANNOSAURUS_PERSISTENCE
+  }),
+  Object.freeze({
+    avatarIdentifier: AvatarId.TRICERATOPS,
+    avatarResourcePath: AvatarAssetPath.TRICERATOPS,
+    persistenceDescription: AvatarSelectionScenarioDescription.TRICERATOPS_PERSISTENCE
+  })
+]);
+
+const AvatarResourceEntries = (() => {
+  const baseEntries = [
+    Object.freeze([AvatarId.SUNNY_GIRL, AvatarAssetPath.SUNNY_GIRL]),
+    Object.freeze([AvatarId.CURIOUS_GIRL, AvatarAssetPath.CURIOUS_GIRL]),
+    Object.freeze([AvatarId.ADVENTUROUS_BOY, AvatarAssetPath.ADVENTUROUS_BOY]),
+    Object.freeze([AvatarId.CREATIVE_BOY, AvatarAssetPath.CREATIVE_BOY])
+  ];
+
+  for (const dinosaurAvatarDescriptor of DinosaurAvatarDescriptors) {
+    baseEntries.push(
+      Object.freeze([
+        dinosaurAvatarDescriptor.avatarIdentifier,
+        dinosaurAvatarDescriptor.avatarResourcePath
+      ])
+    );
   }
-];
+
+  return Object.freeze(baseEntries);
+})();
+
+const AvatarSelectionScenarios = (() => {
+  const scenarios = [
+    Object.freeze({
+      description: AvatarSelectionScenarioDescription.CREATIVE_PERSISTENCE,
+      chosenAvatarId: AvatarId.CREATIVE_BOY
+    })
+  ];
+
+  for (const dinosaurAvatarDescriptor of DinosaurAvatarDescriptors) {
+    scenarios.push(
+      Object.freeze({
+        description: dinosaurAvatarDescriptor.persistenceDescription,
+        chosenAvatarId: dinosaurAvatarDescriptor.avatarIdentifier
+      })
+    );
+  }
+
+  return Object.freeze(scenarios);
+})();
 
 afterEach(() => {
   document.body.innerHTML = EmptyStringValue;

--- a/tests/unit/resultCard.test.js
+++ b/tests/unit/resultCard.test.js
@@ -26,6 +26,8 @@ const TestDescription = Object.freeze({
   RENDER_IMAGE_PATH: "renders <image> element for avatar resource paths when allergen is present",
   RENDER_IMAGE_PATH_TYRANNOSAURUS:
     "renders <image> element for the tyrannosaurus rex avatar resource when allergen is present",
+  RENDER_IMAGE_PATH_TRICERATOPS:
+    "renders <image> element for the triceratops avatar resource when allergen is present",
   UPDATE_INVALID_FALLBACK: "falls back to default avatar when provided identifier is invalid",
   UPDATE_PATH_IMMEDIATE_RENDER: "renders avatar image immediately when avatar selection changes",
   UPDATE_PATH_TYRANNOSAURUS:
@@ -136,6 +138,16 @@ const RevealCardAvatarRenderingCases = [
     selectedAvatarId: AvatarId.TYRANNOSAURUS_REX,
     avatarResourceType: AvatarResourceType.PATH,
     expectedMarkup: AvatarAssetPath.TYRANNOSAURUS_REX
+  },
+  {
+    description: TestDescription.RENDER_IMAGE_PATH_TRICERATOPS,
+    avatarMapEntries: [
+      [AvatarId.SUNNY_GIRL, AvatarMarkup.SUNNY],
+      [AvatarId.TRICERATOPS, AvatarAssetPath.TRICERATOPS]
+    ],
+    selectedAvatarId: AvatarId.TRICERATOPS,
+    avatarResourceType: AvatarResourceType.PATH,
+    expectedMarkup: AvatarAssetPath.TRICERATOPS
   }
 ];
 


### PR DESCRIPTION
## Summary
- share dinosaur avatar descriptors in the avatar selection tests to extend resource entries and persistence cases
- cover dinosaur avatar rendering in the integration harness test cases
- add triceratops path expectations to the result card table-driven scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca50a7861483279ee0a086e229829a