### PR TITLE
Update avatar documentation to include dinosaurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ The Jest harness is configured for a jsdom environment so the integration tests 
 
 ## Avatar customization
 
-Players can personalize the result card by choosing from four built-in avatars: Sunny Girl, Curious Girl, Adventurous Boy, and Creative Boy. The currently selected avatar is displayed in the header toggle button and on the allergy result card during the reveal sequence.
+Players can personalize the result card by choosing from six built-in avatars: Sunny Girl, Curious Girl, Adventurous Boy, Creative Boy, T-Rex, and Triceratops. The currently selected avatar is displayed in the header toggle button and on the allergy result card during the reveal sequence.
 
 To change avatars, click the avatar button in the header to open the selector menu. Choosing any option updates the header image immediately, closes the menu, and persists the selection so the reveal card shows the same avatar until a different option is picked.

--- a/doc/avatars.md
+++ b/doc/avatars.md
@@ -4,6 +4,17 @@ The SVG illustrations stored in `assets/avatars/` were custom-created for this p
 experience under the same license that governs the rest of the repository. Please reach out to the maintainers before reusing the
 artwork in other projects if the repository license does not cover your intended use.
 
+## Available avatars
+
+The game currently includes the following six selectable avatars:
+
+- Sunny Girl
+- Curious Girl
+- Adventurous Boy
+- Creative Boy
+- T-Rex
+- Triceratops
+
 ## Contributing new avatars
 
 - Submit only artwork that you created yourself or that you have explicit permission to redistribute with attribution details.


### PR DESCRIPTION
## Summary
- document the full list of six avatars in the README
- add an avatar roster section to doc/avatars.md so the dinosaur options are included

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca528aae388327b77fbc72d8c2b8fd