### PR TITLE
Define chip radio CSS variables in root

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,12 @@
             --chip-shadow: 2px 2px 0 #000;
             --chip-hover-shadow: 3px 3px 0 #000;
             --chip-radio-accent: #ffcc4d;
+            --chip-radio-size: 20px;
+            --chip-border: #000;
+            --chip-radio-shadow: 2px 2px 0 #000;
+            --chip-radio-dot-size: 10px;
+            --chip-radio-color: #000;
+            --chip-focus-ring: #000;
             --chip-text: #2b1b05;
             --start-button-bg: linear-gradient(135deg, #ffe066 0%, #ffc857 100%);
             --start-button-hover-bg: linear-gradient(135deg, #ffec85 0%, #ffd45a 100%);


### PR DESCRIPTION
## Summary
- define the chip radio CSS custom properties at the root level using their literal values
- ensure the card radio controls regain the intended size, border, shadow, and focus outline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca5a61cae083279bba65e429ebdefd