### PR TITLE
Restore allergen card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,25 +32,25 @@
             --card: #fff;
             --muted: #666;
             --shadow: 0 12px 30px rgba(0, 0, 0, .15);
-            --chip-bg: #fff3c2;
-            --chip-hover-bg: #ffe799;
-            --chip-selected-bg: #ffe08a;
+            --chip-bg: #fff7c8;
+            --chip-hover-bg: #fff1a1;
+            --chip-selected-bg: #ffe485;
             --chip-border: #000;
-            --chip-shadow: 3px 3px 0 #000;
-            --chip-hover-shadow: 4px 4px 0 #000;
-            --chip-text: #2a1f00;
+            --chip-shadow: 2px 2px 0 #000;
+            --chip-hover-shadow: 3px 3px 0 #000;
+            --chip-text: #2b1b05;
             --chip-focus-ring: #000;
-            --chip-radio-size: 26px;
-            --chip-radio-dot-size: 12px;
+            --chip-radio-size: 20px;
+            --chip-radio-dot-size: 10px;
             --chip-radio-shadow: 2px 2px 0 #000;
-            --chip-radio-color: var(--primary);
-            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
-            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
-            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
-            --start-button-text: var(--ink);
-            --start-button-disabled-text: rgba(255, 255, 255, 0.85);
+            --chip-radio-color: #000;
+            --start-button-bg: linear-gradient(135deg, #ffe066 0%, #ffc857 100%);
+            --start-button-hover-bg: linear-gradient(135deg, #ffec85 0%, #ffd45a 100%);
+            --start-button-disabled-bg: linear-gradient(135deg, #f2e8c2 0%, #e5d6a3 100%);
+            --start-button-text: #2b1b05;
+            --start-button-disabled-text: rgba(43, 27, 5, 0.7);
             --start-button-shadow: 4px 6px 0 #000;
-            --start-button-hover-shadow: 5px 7px 0 #000
+            --start-button-hover-shadow: 5px 7px 0 #000;
         }
 
         html, body { height: 100% }
@@ -275,6 +275,26 @@
             display: flex;
             flex-direction: column;
             gap: clamp(18px, 3vw, 28px);
+        }
+
+        .card--allergen {
+            --chip-bg: #fff3c2;
+            --chip-hover-bg: #ffe799;
+            --chip-selected-bg: #ffe08a;
+            --chip-border: #000;
+            --chip-shadow: 3px 3px 0 #000;
+            --chip-hover-shadow: 4px 4px 0 #000;
+            --chip-text: #2a1f00;
+            --chip-focus-ring: #000;
+            --chip-radio-size: 26px;
+            --chip-radio-dot-size: 12px;
+            --chip-radio-shadow: 2px 2px 0 #000;
+            --chip-radio-color: var(--primary);
+            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
+            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
+            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
+            --start-button-text: var(--ink);
+            --start-button-disabled-text: rgba(255, 255, 255, 0.85);
         }
 
         .card::before {
@@ -609,7 +629,7 @@
 
 <!-- Allergy selection -->
 <main id="screen-allergy">
-    <div class="card">
+    <div class="card card--allergen">
         <div class="card__body">
             <h2 class="title" id="allergy-title">Pick your allergens</h2>
             <p class="muted">Choose anything that might cause trouble. You can change this later.</p>

--- a/index.html
+++ b/index.html
@@ -32,18 +32,23 @@
             --card: #fff;
             --muted: #666;
             --shadow: 0 12px 30px rgba(0, 0, 0, .15);
-            --chip-bg: #fff7c8;
-            --chip-hover-bg: #fff1a1;
-            --chip-selected-bg: #ffe485;
-            --chip-shadow: 2px 2px 0 #000;
-            --chip-hover-shadow: 3px 3px 0 #000;
-            --chip-radio-accent: #ffcc4d;
-            --chip-text: #2b1b05;
-            --start-button-bg: linear-gradient(135deg, #ffe066 0%, #ffc857 100%);
-            --start-button-hover-bg: linear-gradient(135deg, #ffec85 0%, #ffd45a 100%);
-            --start-button-disabled-bg: linear-gradient(135deg, #f2e8c2 0%, #e5d6a3 100%);
-            --start-button-text: #2b1b05;
-            --start-button-disabled-text: rgba(43, 27, 5, 0.7);
+            --chip-bg: #fff3c2;
+            --chip-hover-bg: #ffe799;
+            --chip-selected-bg: #ffe08a;
+            --chip-border: #000;
+            --chip-shadow: 3px 3px 0 #000;
+            --chip-hover-shadow: 4px 4px 0 #000;
+            --chip-text: #2a1f00;
+            --chip-focus-ring: #000;
+            --chip-radio-size: 26px;
+            --chip-radio-dot-size: 12px;
+            --chip-radio-shadow: 2px 2px 0 #000;
+            --chip-radio-color: var(--primary);
+            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
+            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
+            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
+            --start-button-text: var(--ink);
+            --start-button-disabled-text: rgba(255, 255, 255, 0.85);
             --start-button-shadow: 4px 6px 0 #000;
             --start-button-hover-shadow: 5px 7px 0 #000
         }
@@ -345,9 +350,8 @@
             font-size: clamp(22px, 3vw, 28px);
             font-weight: 900;
             inline-size: 100%;
-            min-height: clamp(68px, 12vw, 96px);
-            line-height: 1.2;
-            text-align: center;
+            max-inline-size: 280px;
+            min-height: clamp(72px, 12vw, 100px);
             background: var(--start-button-bg);
             color: var(--start-button-text);
             border: 4px solid #000;
@@ -403,62 +407,35 @@
             margin: 0;
         }
 
-        @media (max-width: 960px) {
-            .allergen-grid {
-                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        @media (max-width: 640px) {
+            .allergen-grid .start-button {
+                justify-self: stretch;
             }
 
-            .allergen-grid .start-button {
-                grid-column: 1 / -1;
+            .btn.start-button {
+                max-inline-size: none;
             }
         }
 
         .chip {
             display: flex;
             align-items: center;
-            gap: 12px;
-            padding: 12px 16px;
+            gap: clamp(12px, 2vw, 16px);
+            padding: clamp(16px, 2.8vw, 22px) clamp(18px, 3.2vw, 26px);
             border-radius: 999px;
             background: var(--chip-bg);
-            border: 2px solid #000;
+            border: 3px solid var(--chip-border);
             box-shadow: var(--chip-shadow);
-            cursor: pointer;
+            color: var(--chip-text);
             font-family: "Fredoka One", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
             font-weight: 900;
             letter-spacing: .2px;
             font-size: clamp(16px, 1.6vw, 20px);
-            color: var(--chip-text);
+            cursor: pointer;
             transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
             inline-size: 100%;
             min-height: clamp(72px, 12vw, 92px);
             line-height: 1;
-        }
-
-        .chip:hover,
-        .chip:focus-visible {
-            background: var(--chip-hover-bg);
-            box-shadow: var(--chip-hover-shadow);
-            transform: translateY(-1px);
-            outline: none;
-        }
-
-        .chip--selected {
-            background: var(--chip-selected-bg);
-            box-shadow: var(--chip-hover-shadow);
-            transform: translateY(-1px);
-        }
-
-        .chip__radio {
-            inline-size: 20px;
-            block-size: 20px;
-            flex-shrink: 0;
-            accent-color: var(--chip-radio-accent);
-            cursor: pointer;
-        }
-
-        .chip__radio:focus-visible {
-            outline: 3px solid var(--chip-radio-accent);
-            outline-offset: 2px;
         }
 
         .chip__label {
@@ -471,12 +448,14 @@
             line-height: 1;
         }
 
-        @supports selector(:has(*)) {
-            .chip:has(.chip__radio:focus-visible) {
-                background: var(--chip-hover-bg);
-                box-shadow: var(--chip-hover-shadow);
-                transform: translateY(-1px);
-            }
+        .chip:is(:hover, :focus-within) {
+            background: var(--chip-hover-bg);
+            box-shadow: var(--chip-hover-shadow);
+            transform: translateY(-2px);
+        }
+
+        .chip:focus-visible {
+            outline: none;
         }
 
         .chip:focus-within {

--- a/index.html
+++ b/index.html
@@ -32,23 +32,23 @@
             --card: #fff;
             --muted: #666;
             --shadow: 0 12px 30px rgba(0, 0, 0, .15);
-            --chip-bg: #fff7c8;
-            --chip-hover-bg: #fff1a1;
-            --chip-selected-bg: #ffe485;
+            --chip-bg: #fff3c2;
+            --chip-hover-bg: #ffe799;
+            --chip-selected-bg: #ffe08a;
             --chip-border: #000;
-            --chip-shadow: 2px 2px 0 #000;
-            --chip-hover-shadow: 3px 3px 0 #000;
-            --chip-text: #2b1b05;
+            --chip-shadow: 3px 3px 0 #000;
+            --chip-hover-shadow: 4px 4px 0 #000;
+            --chip-text: #2a1f00;
             --chip-focus-ring: #000;
-            --chip-radio-size: 20px;
-            --chip-radio-dot-size: 10px;
+            --chip-radio-size: 26px;
+            --chip-radio-dot-size: 12px;
             --chip-radio-shadow: 2px 2px 0 #000;
-            --chip-radio-color: #000;
-            --start-button-bg: linear-gradient(135deg, #ffe066 0%, #ffc857 100%);
-            --start-button-hover-bg: linear-gradient(135deg, #ffec85 0%, #ffd45a 100%);
-            --start-button-disabled-bg: linear-gradient(135deg, #f2e8c2 0%, #e5d6a3 100%);
-            --start-button-text: #2b1b05;
-            --start-button-disabled-text: rgba(43, 27, 5, 0.7);
+            --chip-radio-color: var(--primary);
+            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
+            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
+            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
+            --start-button-text: var(--ink);
+            --start-button-disabled-text: rgba(255, 255, 255, 0.85);
             --start-button-shadow: 4px 6px 0 #000;
             --start-button-hover-shadow: 5px 7px 0 #000;
         }
@@ -277,26 +277,6 @@
             gap: clamp(18px, 3vw, 28px);
         }
 
-        .card--allergen {
-            --chip-bg: #fff3c2;
-            --chip-hover-bg: #ffe799;
-            --chip-selected-bg: #ffe08a;
-            --chip-border: #000;
-            --chip-shadow: 3px 3px 0 #000;
-            --chip-hover-shadow: 4px 4px 0 #000;
-            --chip-text: #2a1f00;
-            --chip-focus-ring: #000;
-            --chip-radio-size: 26px;
-            --chip-radio-dot-size: 12px;
-            --chip-radio-shadow: 2px 2px 0 #000;
-            --chip-radio-color: var(--primary);
-            --start-button-bg: linear-gradient(135deg, #ff8fb3 0%, #ff6f9f 100%);
-            --start-button-hover-bg: linear-gradient(135deg, #ff96b8 0%, #ff77a6 100%);
-            --start-button-disabled-bg: linear-gradient(135deg, #ffd6e5 0%, #ffc0d5 100%);
-            --start-button-text: var(--ink);
-            --start-button-disabled-text: rgba(255, 255, 255, 0.85);
-        }
-
         .card::before {
             content: "";
             position: absolute;
@@ -411,7 +391,7 @@
 
         .grid { display: grid; gap: clamp(12px, 2vw, 20px) }
 
-        .allergen-grid {
+        .card--allergen .allergen-grid {
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
             grid-auto-rows: minmax(84px, auto);
             align-content: start;
@@ -420,7 +400,7 @@
             padding-block: clamp(8px, 2vw, 16px);
         }
 
-        .allergen-grid .start-button {
+        .card--allergen .allergen-grid .start-button {
             grid-column: -1;
             align-self: end;
             justify-self: end;
@@ -428,7 +408,7 @@
         }
 
         @media (max-width: 640px) {
-            .allergen-grid .start-button {
+            .card--allergen .allergen-grid .start-button {
                 justify-self: stretch;
             }
 
@@ -437,7 +417,7 @@
             }
         }
 
-        .chip {
+        .card--allergen .chip {
             display: flex;
             align-items: center;
             gap: clamp(12px, 2vw, 16px);
@@ -458,38 +438,38 @@
             line-height: 1;
         }
 
-        .chip__label {
+        .card--allergen .chip__label {
             flex: 1 1 auto;
             line-height: 1.15;
         }
 
-        .chip__emoji {
+        .card--allergen .chip__emoji {
             margin-inline-start: auto;
             line-height: 1;
         }
 
-        .chip:is(:hover, :focus-within) {
+        .card--allergen .chip:is(:hover, :focus-within) {
             background: var(--chip-hover-bg);
             box-shadow: var(--chip-hover-shadow);
             transform: translateY(-2px);
         }
 
-        .chip:focus-visible {
+        .card--allergen .chip:focus-visible {
             outline: none;
         }
 
-        .chip:focus-within {
+        .card--allergen .chip:focus-within {
             outline: 3px solid var(--chip-focus-ring);
             outline-offset: 2px;
         }
 
-        .chip--selected {
+        .card--allergen .chip--selected {
             background: var(--chip-selected-bg);
             box-shadow: var(--chip-hover-shadow);
             transform: translateY(-2px);
         }
 
-        .chip__radio {
+        .card--allergen .chip__radio {
             appearance: none;
             inline-size: var(--chip-radio-size);
             block-size: var(--chip-radio-size);
@@ -503,7 +483,7 @@
             flex-shrink: 0;
         }
 
-        .chip__radio::after {
+        .card--allergen .chip__radio::after {
             content: "";
             inline-size: var(--chip-radio-dot-size);
             block-size: var(--chip-radio-dot-size);
@@ -513,20 +493,20 @@
             transition: transform 140ms ease;
         }
 
-        .chip__radio:checked::after {
+        .card--allergen .chip__radio:checked::after {
             transform: scale(1);
         }
 
-        .chip__radio:focus-visible {
+        .card--allergen .chip__radio:focus-visible {
             outline: 3px solid var(--chip-focus-ring);
             outline-offset: 2px;
         }
 
-        .chip__radio:active {
+        .card--allergen .chip__radio:active {
             transform: scale(0.95);
         }
 
-        .chip--selected .chip__radio {
+        .card--allergen .chip--selected .chip__radio {
             box-shadow: var(--chip-radio-shadow), inset 0 0 0 3px #fff;
         }
 


### PR DESCRIPTION
## Summary
- restore the allergen selection card to the morning visual design, including chip spacing, radio styling, and start button layout
- retune the first-card CSS custom properties so the chip colors and gradients match the earlier pink theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca5a61cae083279bba65e429ebdefd