### PR TITLE
Trim duplicate chip chip styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,8 +455,8 @@
         }
 
         .chip__radio {
-            inline-size: 20px;
-            block-size: 20px;
+            inline-size: var(--chip-radio-size);
+            block-size: var(--chip-radio-size);
             flex-shrink: 0;
             accent-color: var(--chip-radio-accent);
             cursor: pointer;
@@ -490,51 +490,42 @@
             outline-offset: 2px;
         }
 
-        .chip--selected {
-            background: var(--chip-selected-bg);
-            box-shadow: var(--chip-hover-shadow);
-            transform: translateY(-2px);
-        }
+        @supports (appearance: none) or (-webkit-appearance: none) {
+            .chip__radio {
+                appearance: none;
+                -webkit-appearance: none;
+                inline-size: var(--chip-radio-size);
+                block-size: var(--chip-radio-size);
+                border-radius: 50%;
+                border: 3px solid var(--chip-border);
+                background: #fff;
+                box-shadow: var(--chip-radio-shadow);
+                display: grid;
+                place-items: center;
+                transition: transform 140ms ease, box-shadow 140ms ease;
+            }
 
-        .chip__radio {
-            appearance: none;
-            inline-size: var(--chip-radio-size);
-            block-size: var(--chip-radio-size);
-            border-radius: 50%;
-            border: 3px solid var(--chip-border);
-            background: #fff;
-            box-shadow: var(--chip-radio-shadow);
-            display: grid;
-            place-items: center;
-            transition: transform 140ms ease, box-shadow 140ms ease;
-            flex-shrink: 0;
-        }
+            .chip__radio::after {
+                content: "";
+                inline-size: var(--chip-radio-dot-size);
+                block-size: var(--chip-radio-dot-size);
+                border-radius: 50%;
+                background: var(--chip-radio-color);
+                transform: scale(0);
+                transition: transform 140ms ease;
+            }
 
-        .chip__radio::after {
-            content: "";
-            inline-size: var(--chip-radio-dot-size);
-            block-size: var(--chip-radio-dot-size);
-            border-radius: 50%;
-            background: var(--chip-radio-color);
-            transform: scale(0);
-            transition: transform 140ms ease;
-        }
+            .chip__radio:checked::after {
+                transform: scale(1);
+            }
 
-        .chip__radio:checked::after {
-            transform: scale(1);
-        }
+            .chip__radio:active {
+                transform: scale(0.95);
+            }
 
-        .chip__radio:focus-visible {
-            outline: 3px solid var(--chip-focus-ring);
-            outline-offset: 2px;
-        }
-
-        .chip__radio:active {
-            transform: scale(0.95);
-        }
-
-        .chip--selected .chip__radio {
-            box-shadow: var(--chip-radio-shadow), inset 0 0 0 3px #fff;
+            .chip--selected .chip__radio {
+                box-shadow: var(--chip-radio-shadow), inset 0 0 0 3px #fff;
+            }
         }
 
         /* Exclusive screens */


### PR DESCRIPTION
## Summary
- clean up duplicate chip selection and radio styles in the inline stylesheet
- wrap the custom radio control styling in an @supports block so the morning fallback remains intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca6790349c83278a2f082897f27b56