### PR TITLE
Adjust allergen chip emoji styling

### DIFF
--- a/firstCard.js
+++ b/firstCard.js
@@ -100,7 +100,7 @@ export class AllergenCard {
             labelSpan.textContent = allergenLabel;
 
             const emojiSpan = document.createElement(ElementTagName.SPAN);
-            emojiSpan.classList.add(ElementClassName.EMOJI_LARGE, ElementClassName.CHIP_EMOJI);
+            emojiSpan.classList.add(ElementClassName.CHIP_EMOJI);
             emojiSpan.textContent = allergenEmoji;
             emojiSpan.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
 

--- a/index.html
+++ b/index.html
@@ -475,6 +475,7 @@
         .chip__emoji {
             margin-inline-start: auto;
             line-height: 1;
+            font-size: 2em;
         }
 
         @supports selector(:has(*)) {


### PR DESCRIPTION
## Summary
- stop applying the large emoji helper class to allergen chips while leaving badge behavior intact
- specify the chip emoji font-size directly in the stylesheet to retain the intended card layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca68cb7ca88327816e088a2b2918a1