### PR TITLE
Align start button styling with brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,11 +45,11 @@
             --chip-radio-color: #000;
             --chip-focus-ring: #000;
             --chip-text: #2b1b05;
-            --start-button-bg: linear-gradient(135deg, #ffe066 0%, #ffc857 100%);
-            --start-button-hover-bg: linear-gradient(135deg, #ffec85 0%, #ffd45a 100%);
-            --start-button-disabled-bg: linear-gradient(135deg, #f2e8c2 0%, #e5d6a3 100%);
-            --start-button-text: #2b1b05;
-            --start-button-disabled-text: rgba(43, 27, 5, 0.7);
+            --start-button-bg: var(--primary);
+            --start-button-hover-bg: #ff6f87;
+            --start-button-disabled-bg: #ff99ae;
+            --start-button-text: var(--ink);
+            --start-button-disabled-text: rgba(255, 255, 255, 0.78);
             --start-button-shadow: 4px 6px 0 #000;
             --start-button-hover-shadow: 5px 7px 0 #000
         }
@@ -348,16 +348,16 @@
             min-height: clamp(68px, 12vw, 96px);
             line-height: 1.2;
             text-align: center;
-            background: var(--start-button-bg);
+            background-color: var(--start-button-bg);
             color: var(--start-button-text);
             border: 4px solid #000;
             box-shadow: var(--start-button-shadow);
-            transition: background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+            transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease, color 160ms ease;
         }
 
         .btn.start-button:hover,
         .btn.start-button:focus-visible {
-            background: var(--start-button-hover-bg);
+            background-color: var(--start-button-hover-bg);
             box-shadow: var(--start-button-hover-shadow);
             transform: translateY(-2px);
             outline: none;
@@ -366,7 +366,7 @@
 
         .start-button[data-blocked="true"] {
             cursor: pointer;
-            background: var(--start-button-disabled-bg);
+            background-color: var(--start-button-disabled-bg);
             color: var(--start-button-disabled-text);
             box-shadow: var(--start-button-shadow);
             opacity: 0.82;
@@ -375,7 +375,7 @@
 
         .start-button[data-blocked="true"]:hover,
         .start-button[data-blocked="true"]:focus-visible {
-            background: var(--start-button-disabled-bg);
+            background-color: var(--start-button-disabled-bg);
             box-shadow: var(--start-button-shadow);
             transform: none;
         }


### PR DESCRIPTION
## Summary
- update the start button theme variables to reuse the primary brand palette for default, hover, and disabled states
- adjust the start button styles to apply the new tokens while preserving the legacy typography, border, and shadow treatments

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ca6d5bd724832785af4db11ee3d804