### PR TITLE
Restore card border-box sizing to prevent overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,7 @@
         .card {
             --card-inset: clamp(16px, 2.8vw, 24px);
             width: min(900px, 92vw);
+            box-sizing: border-box;
             position: relative;
             z-index: 0;
             isolation: isolate;


### PR DESCRIPTION
## Summary
- add `box-sizing: border-box` to the `.card` rule so its width includes padding and borders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca714dfcc88327bc6edd10be9a49cb