### PR TITLE
Adjust allergen chip sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,7 +390,6 @@
 
         .allergen-grid {
             grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-            grid-auto-rows: minmax(84px, auto);
             align-content: start;
             justify-items: stretch;
             grid-auto-flow: row dense;
@@ -418,7 +417,8 @@
             display: flex;
             align-items: center;
             gap: 12px;
-            padding: 12px 16px;
+            padding-block: clamp(6px, 1.4vw, 10px);
+            padding-inline: clamp(14px, 2.4vw, 18px);
             border-radius: 999px;
             background: var(--chip-bg);
             border: 2px solid #000;
@@ -430,8 +430,6 @@
             font-size: clamp(16px, 1.6vw, 20px);
             color: var(--chip-text);
             transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
-            inline-size: 100%;
-            min-height: clamp(72px, 12vw, 92px);
             line-height: 1;
         }
 


### PR DESCRIPTION
## Summary
- remove the fixed grid auto-row height so allergen cells shrink to match their content
- slim down chip padding and remove forced sizing so the pills render as thinner capsules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca7349ef24832784289e2c79aced80