### PR TITLE
Adjust desktop allergen grid to three columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,7 +389,7 @@
         .grid { display: grid; gap: clamp(12px, 2vw, 20px) }
 
         .allergen-grid {
-            grid-template-columns: repeat(auto-fit, minmax(188px, 1fr));
+            grid-template-columns: repeat(3, minmax(0, 1fr));
             align-content: start;
             justify-items: stretch;
             grid-auto-flow: row dense;
@@ -397,7 +397,7 @@
         }
 
         .allergen-grid .start-button {
-            grid-column: -1;
+            grid-column: 3 / 4;
             align-self: end;
             justify-self: end;
             margin: 0;


### PR DESCRIPTION
## Summary
- set the desktop allergen grid to always render three columns
- keep the start button anchored to the final column so it stays bottom-right when chips wrap

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae08c907883279862ec729b376f43