### PR TITLE
Adjust desktop start button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,9 +397,9 @@
         }
 
         .allergen-grid .start-button {
-            grid-column: 3 / 4;
+            grid-column: 2 / 4;
             align-self: end;
-            justify-self: end;
+            justify-self: stretch;
             margin: 0;
         }
 


### PR DESCRIPTION
## Summary
- stretch the desktop start button across two grid columns and allow it to fill the width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cae4c8dc608327a81de6f69e40145f