### PR TITLE
Add decorative wheel icon to start button

### DIFF
--- a/assets/icons/spinning-wheel.svg
+++ b/assets/icons/spinning-wheel.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="startWheelBase" cx="50%" cy="38%" r="70%">
+      <stop offset="0%" stop-color="#fff6df"/>
+      <stop offset="100%" stop-color="#ffe5f0"/>
+    </radialGradient>
+  </defs>
+  <circle cx="32" cy="32" r="28" fill="url(#startWheelBase)" stroke="#111" stroke-width="4"/>
+  <path d="M32 32 L32 10 A22 22 0 0 1 54 32 Z" fill="#ffcc4d" stroke="#111" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M32 32 L54 32 A22 22 0 0 1 32 54 Z" fill="#ff6f87" stroke="#111" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M32 32 L32 54 A22 22 0 0 1 10 32 Z" fill="#7bdff2" stroke="#111" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M32 32 L10 32 A22 22 0 0 1 32 10 Z" fill="#ff9f80" stroke="#111" stroke-width="2" stroke-linejoin="round"/>
+  <circle cx="32" cy="32" r="11" fill="#fff7c8" stroke="#111" stroke-width="2"/>
+  <circle cx="32" cy="32" r="5" fill="#ff4d6d" stroke="#111" stroke-width="1.5"/>
+  <path d="M32 2 L26 16 L38 16 Z" fill="#ff4d6d" stroke="#111" stroke-width="3" stroke-linejoin="round"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -342,6 +342,10 @@
             display: inline-flex;
             align-items: center;
             justify-content: center;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            --start-button-icon-size: clamp(28px, 5vw, 40px);
+            --start-button-icon-spacing: clamp(10px, 2.8vw, 18px);
             padding: clamp(20px, 3.2vw, 28px) clamp(32px, 5vw, 56px);
             font-size: clamp(22px, 3vw, 28px);
             font-weight: 900;
@@ -354,6 +358,23 @@
             border: 4px solid #000;
             box-shadow: var(--start-button-shadow);
             transition: background-color 160ms ease, box-shadow 160ms ease, transform 160ms ease, color 160ms ease;
+        }
+
+        .btn.start-button .start-button__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            inline-size: var(--start-button-icon-size);
+            block-size: var(--start-button-icon-size);
+            margin-right: var(--start-button-icon-spacing);
+            flex-shrink: 0;
+        }
+
+        .btn.start-button .start-button__icon svg,
+        .btn.start-button .start-button__icon img {
+            display: block;
+            inline-size: 100%;
+            block-size: 100%;
         }
 
         .btn.start-button:hover,
@@ -639,6 +660,9 @@
                     id="start"
                     type="button"
                 >
+                    <span aria-hidden="true" class="start-button__icon">
+                        <img alt="" src="assets/icons/spinning-wheel.svg"/>
+                    </span>
                     Spin the Wheel
                 </button>
             </div>


### PR DESCRIPTION
## Summary
- add a spinning wheel SVG icon that fits the existing palette for reuse in the start button
- inject the decorative icon span into the start button markup and update flexbox styling for aligned spacing
- size the icon responsively with CSS custom properties so the layout remains intact on smaller breakpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae87fc8d48327a8770940b89ab1ea