### PR TITLE
Add audio mute controls and state management

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,13 @@ import { NormalizationEngine, loadJson, pickRandomUnique } from "./utils.js";
 import { AllergenCard } from "./firstCard.js";
 import { ResultCard } from "./lastCard.js";
 import { renderHearts, animateHeartGainFromReveal, animateHeartLossAtHeartsBar } from "./hearts.js";
-import { primeAudioOnFirstGesture, playTick, playSiren, playNomNom, playWin } from "./audio.js";
+import {
+    primeAudioOnFirstGesture as primeAudioOnFirstGestureEffect,
+    playTick as playTickEffect,
+    playSiren as playSirenEffect,
+    playNomNom as playNomNomEffect,
+    playWin as playWinEffect
+} from "./audio.js";
 import { showScreen, setWheelControlToStop, setWheelControlToStartGame } from "./ui.js";
 import {
     ControlElementId,
@@ -141,12 +147,45 @@ const heartsPresenter = {
     animateHeartLossAtHeartsBar
 };
 
+let cachedAudioMutedState = stateManager.isAudioMuted();
+
+const shouldPlayAudio = () => {
+    const isMuted = stateManager.isAudioMuted();
+    cachedAudioMutedState = isMuted;
+    return isMuted === false;
+};
+
 const audioPresenter = {
-    primeAudioOnFirstGesture,
-    playTick,
-    playSiren,
-    playNomNom,
-    playWin
+    primeAudioOnFirstGesture: () => {
+        primeAudioOnFirstGestureEffect();
+    },
+    playTick: (...args) => {
+        if (!shouldPlayAudio()) {
+            return;
+        }
+        playTickEffect(...args);
+    },
+    playSiren: (...args) => {
+        if (!shouldPlayAudio()) {
+            return;
+        }
+        playSirenEffect(...args);
+    },
+    playNomNom: (...args) => {
+        if (!shouldPlayAudio()) {
+            return;
+        }
+        playNomNomEffect(...args);
+    },
+    playWin: (...args) => {
+        if (!shouldPlayAudio()) {
+            return;
+        }
+        playWinEffect(...args);
+    },
+    handleMuteToggle: (isMuted) => {
+        cachedAudioMutedState = Boolean(isMuted);
+    }
 };
 
 const uiPresenter = {

--- a/constants.js
+++ b/constants.js
@@ -54,6 +54,7 @@ export const ControlElementId = Object.freeze({
     START_BUTTON: "start",
     STOP_BUTTON: "stop",
     FULLSCREEN_BUTTON: "fs",
+    MUTE_BUTTON: "mute",
     SPIN_AGAIN_BUTTON: "again",
     REVEAL_SECTION: "reveal",
     GAME_OVER_SECTION: "gameover",
@@ -112,6 +113,7 @@ export const HeartsElementId = Object.freeze({
 export const AttributeName = Object.freeze({
     ARIA_HIDDEN: "aria-hidden",
     ARIA_LABEL: "aria-label",
+    ARIA_PRESSED: "aria-pressed",
     ARIA_EXPANDED: "aria-expanded",
     ARIA_DISABLED: "aria-disabled",
     DATA_SCREEN: "data-screen",
@@ -140,5 +142,12 @@ export const KeyboardKey = Object.freeze({
 export const ButtonText = Object.freeze({
     START: "Start",
     STOP: "STOP",
-    RESTART: "Restart"
+    RESTART: "Restart",
+    MUTE: "Mute",
+    SOUND_ON: "Sound On"
+});
+
+export const AudioControlLabel = Object.freeze({
+    MUTE_AUDIO: "Mute audio",
+    UNMUTE_AUDIO: "Unmute audio"
 });

--- a/game.js
+++ b/game.js
@@ -438,6 +438,7 @@ export class GameController {
             wireStartButton,
             wireStopButton,
             wireFullscreenButton,
+            wireMuteButton,
             wireSpinAgainButton,
             wireRevealBackdropDismissal,
             wireRestartButton
@@ -472,6 +473,16 @@ export class GameController {
         }
         if (typeof wireFullscreenButton === "function") {
             wireFullscreenButton();
+        }
+        if (typeof wireMuteButton === "function") {
+            wireMuteButton({
+                onMuteChange: (isMuted) => {
+                    if (typeof this.#audioPresenter.handleMuteToggle === "function") {
+                        this.#audioPresenter.handleMuteToggle(isMuted);
+                    }
+                    return isMuted;
+                }
+            });
         }
         if (typeof wireSpinAgainButton === "function") {
             wireSpinAgainButton({

--- a/index.html
+++ b/index.html
@@ -169,6 +169,12 @@
             cursor: pointer
         }
 
+        .ghost[aria-pressed="true"] {
+            background: var(--primary);
+            color: var(--ink);
+            box-shadow: 3px 3px 0 #000;
+        }
+
         /* Hearts bar */
         .hearts {
             position: relative; /* required for delta bubble positioning */
@@ -643,6 +649,7 @@
     <div class="header-right">
         <div aria-live="polite" class="hearts" id="hearts-bar" title="Hearts"></div>
         <button class="ghost" id="fs">Full Screen</button>
+        <button type="button" class="ghost" id="mute" aria-pressed="false" aria-label="Mute audio">Mute</button>
     </div>
 </header>
 

--- a/state.js
+++ b/state.js
@@ -32,6 +32,8 @@ class StateManager {
 
     #selectedAvatarId = AvatarId.DEFAULT;
 
+    #audioMuted = false;
+
     constructor({
         initialHeartsCount = DEFAULT_INITIAL_HEARTS_COUNT,
         initialStopButtonMode = WheelControlMode.STOP
@@ -58,6 +60,7 @@ class StateManager {
         this.#wheelCandidateLabels = [];
         this.#board = null;
         this.#selectedAvatarId = AvatarId.DEFAULT;
+        this.#audioMuted = false;
     }
 
     setBoard(boardInstance) {
@@ -140,6 +143,20 @@ class StateManager {
 
     getStopButtonMode() {
         return this.#stopButtonMode;
+    }
+
+    setAudioMuted(shouldMuteAudio) {
+        this.#audioMuted = Boolean(shouldMuteAudio);
+        return this.#audioMuted;
+    }
+
+    toggleAudioMuted() {
+        this.#audioMuted = !this.#audioMuted;
+        return this.#audioMuted;
+    }
+
+    isAudioMuted() {
+        return this.#audioMuted;
     }
 
     /**

--- a/tests/unit/listeners.test.js
+++ b/tests/unit/listeners.test.js
@@ -1,0 +1,98 @@
+import { jest } from "@jest/globals";
+import { createListenerBinder } from "../../listeners.js";
+import {
+  ControlElementId,
+  AttributeName,
+  AttributeBooleanValue,
+  ButtonText,
+  AudioControlLabel,
+  MODE_STOP
+} from "../../constants.js";
+
+function createStateManagerStub({ initialMuted = false } = {}) {
+  let mutedState = Boolean(initialMuted);
+  return {
+    hasSelectedAllergen: jest.fn(() => false),
+    getStopButtonMode: jest.fn(() => MODE_STOP),
+    isAudioMuted: jest.fn(() => mutedState),
+    toggleAudioMuted: jest.fn(() => {
+      mutedState = !mutedState;
+      return mutedState;
+    }),
+    setAudioMuted: jest.fn((nextState) => {
+      mutedState = Boolean(nextState);
+      return mutedState;
+    })
+  };
+}
+
+const MuteInitializationScenarios = [
+  {
+    description: "applies the unmuted presentation when audio starts active",
+    initialMuted: false,
+    expectedPressed: AttributeBooleanValue.FALSE,
+    expectedText: ButtonText.MUTE,
+    expectedLabel: AudioControlLabel.MUTE_AUDIO
+  },
+  {
+    description: "applies the muted presentation when audio starts disabled",
+    initialMuted: true,
+    expectedPressed: AttributeBooleanValue.TRUE,
+    expectedText: ButtonText.SOUND_ON,
+    expectedLabel: AudioControlLabel.UNMUTE_AUDIO
+  }
+];
+
+describe("listenerBinder wireMuteButton", () => {
+  test.each(MuteInitializationScenarios)(
+    "%s",
+    ({ initialMuted, expectedPressed, expectedText, expectedLabel }) => {
+      document.body.innerHTML = `<button id="${ControlElementId.MUTE_BUTTON}" aria-pressed="false"></button>`;
+      const stateManager = createStateManagerStub({ initialMuted });
+      const binder = createListenerBinder({
+        controlElementId: ControlElementId,
+        attributeName: AttributeName,
+        documentReference: document,
+        stateManager
+      });
+
+      binder.wireMuteButton();
+
+      const muteButton = document.getElementById(ControlElementId.MUTE_BUTTON);
+      expect(muteButton.textContent).toBe(expectedText);
+      expect(muteButton.getAttribute(AttributeName.ARIA_PRESSED)).toBe(expectedPressed);
+      expect(muteButton.getAttribute(AttributeName.ARIA_LABEL)).toBe(expectedLabel);
+    }
+  );
+
+  test("clicking toggles the state and notifies listeners", () => {
+    document.body.innerHTML = `<button id="${ControlElementId.MUTE_BUTTON}" aria-pressed="false"></button>`;
+    const stateManager = createStateManagerStub({ initialMuted: false });
+    const binder = createListenerBinder({
+      controlElementId: ControlElementId,
+      attributeName: AttributeName,
+      documentReference: document,
+      stateManager
+    });
+    const onMuteChange = jest.fn();
+
+    binder.wireMuteButton({ onMuteChange });
+
+    const muteButton = document.getElementById(ControlElementId.MUTE_BUTTON);
+    muteButton.click();
+
+    expect(stateManager.toggleAudioMuted).toHaveBeenCalledTimes(1);
+    expect(onMuteChange).toHaveBeenCalledWith(true);
+    expect(muteButton.getAttribute(AttributeName.ARIA_PRESSED)).toBe(AttributeBooleanValue.TRUE);
+    expect(muteButton.textContent).toBe(ButtonText.SOUND_ON);
+    expect(muteButton.getAttribute(AttributeName.ARIA_LABEL)).toBe(AudioControlLabel.UNMUTE_AUDIO);
+
+    muteButton.click();
+
+    expect(stateManager.toggleAudioMuted).toHaveBeenCalledTimes(2);
+    expect(onMuteChange).toHaveBeenLastCalledWith(false);
+    expect(muteButton.getAttribute(AttributeName.ARIA_PRESSED)).toBe(AttributeBooleanValue.FALSE);
+    expect(muteButton.textContent).toBe(ButtonText.MUTE);
+    expect(muteButton.getAttribute(AttributeName.ARIA_LABEL)).toBe(AudioControlLabel.MUTE_AUDIO);
+  });
+});

--- a/tests/unit/stateManager.test.js
+++ b/tests/unit/stateManager.test.js
@@ -44,7 +44,10 @@ const StateTestDescription = Object.freeze({
   AVATAR_TRICERATOPS_SELECTION: "stores the triceratops avatar identifier when selected",
   AVATAR_INVALID_UNKNOWN: "falls back to the default avatar when given an unknown identifier",
   AVATAR_INVALID_NON_STRING: "falls back to the default avatar when given a non-string identifier",
-  AVATAR_RESET_ON_INITIALIZE: "reinitialize restores the default avatar"
+  AVATAR_RESET_ON_INITIALIZE: "reinitialize restores the default avatar",
+  AUDIO_INITIAL_STATE: "initializes the audio mute flag to false",
+  AUDIO_TOGGLE: "toggleAudioMuted flips the stored mute flag",
+  AUDIO_RESET_ON_INITIALIZE: "initialize resets the audio mute flag"
 });
 
 const InvalidModeValue = Object.freeze({ VALUE: "invalid mode" });
@@ -270,5 +273,31 @@ describe("StateManager stop button mode", () => {
     expect(stateManager.getStopButtonMode()).toBe(MODE_START);
     stateManager.setStopButtonMode(InvalidModeValue.VALUE);
     expect(stateManager.getStopButtonMode()).toBe(MODE_STOP);
+  });
+});
+
+describe("StateManager audio mute state", () => {
+  test(StateTestDescription.AUDIO_INITIAL_STATE, () => {
+    const stateManager = new StateManager();
+    expect(stateManager.isAudioMuted()).toBe(false);
+  });
+
+  test(StateTestDescription.AUDIO_TOGGLE, () => {
+    const stateManager = new StateManager();
+    expect(stateManager.isAudioMuted()).toBe(false);
+    expect(stateManager.setAudioMuted(true)).toBe(true);
+    expect(stateManager.isAudioMuted()).toBe(true);
+    expect(stateManager.toggleAudioMuted()).toBe(false);
+    expect(stateManager.isAudioMuted()).toBe(false);
+    expect(stateManager.toggleAudioMuted()).toBe(true);
+    expect(stateManager.isAudioMuted()).toBe(true);
+  });
+
+  test(StateTestDescription.AUDIO_RESET_ON_INITIALIZE, () => {
+    const stateManager = new StateManager();
+    stateManager.setAudioMuted(true);
+    expect(stateManager.isAudioMuted()).toBe(true);
+    stateManager.initialize();
+    expect(stateManager.isAudioMuted()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add constants and UI updates for a mute button with accessible labels
- track audio mute state in the StateManager and wire the new control through the listener binder and game controller
- guard audio playback through the presenter and extend unit/integration coverage for the mute flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caef49795483278976f4e7eb78ce1b