### PR TITLE
Add numeric heart counter to hearts bar

### DIFF
--- a/hearts.js
+++ b/hearts.js
@@ -10,14 +10,25 @@ const HeartClassName = Object.freeze({
     HEART_GAIN: "heart gain"
 });
 
+const HeartsBarChildClassName = Object.freeze({
+    COUNT: "heart-count",
+    ICONS: "heart-icons"
+});
+
 const HeartSelector = Object.freeze({
     HEART: ".heart"
+});
+
+const HeartsBarChildSelector = Object.freeze({
+    COUNT: `.${HeartsBarChildClassName.COUNT}`,
+    ICONS: `.${HeartsBarChildClassName.ICONS}`
 });
 
 const HeartSymbol = "❤️";
 
 const TextContent = Object.freeze({
     EMPTY: "",
+    ZERO: "0",
     HEART_LABEL_SUFFIX: " hearts"
 });
 
@@ -25,41 +36,81 @@ const NumericBase = Object.freeze({
     DECIMAL: 10
 });
 
-function setMetadataAttributes(heartsBarElement, totalHearts) {
-    const totalLabel = `${totalHearts}${TextContent.HEART_LABEL_SUFFIX}`;
-    heartsBarElement.setAttribute(AttributeName.DATA_COUNT, String(totalHearts));
+function formatHeartsLabel(totalHearts) {
+    return `${totalHearts}${TextContent.HEART_LABEL_SUFFIX}`;
+}
+
+function setMetadataAttributes(heartsBarElement, totalHearts, heartCountText) {
+    const totalLabel = formatHeartsLabel(totalHearts);
+    heartsBarElement.setAttribute(AttributeName.DATA_COUNT, heartCountText);
     heartsBarElement.setAttribute(AttributeName.ARIA_LABEL, totalLabel);
     heartsBarElement.title = totalLabel;
 }
 
-function appendHeartElements(heartsBarElement, totalHearts) {
-    heartsBarElement.innerHTML = TextContent.EMPTY;
+function ensureHeartsBarChildren(heartsBarElement) {
+    let heartCountElement = heartsBarElement.querySelector(HeartsBarChildSelector.COUNT);
+    if (!heartCountElement) {
+        heartCountElement = document.createElement(ElementTagName.SPAN);
+        heartCountElement.className = HeartsBarChildClassName.COUNT;
+        heartsBarElement.insertBefore(heartCountElement, heartsBarElement.firstChild);
+    }
+
+    let heartIconsContainerElement = heartsBarElement.querySelector(HeartsBarChildSelector.ICONS);
+    if (!heartIconsContainerElement) {
+        heartIconsContainerElement = document.createElement(ElementTagName.SPAN);
+        heartIconsContainerElement.className = HeartsBarChildClassName.ICONS;
+        heartIconsContainerElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+        heartsBarElement.appendChild(heartIconsContainerElement);
+    } else if (!heartIconsContainerElement.hasAttribute(AttributeName.ARIA_HIDDEN)) {
+        heartIconsContainerElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+    }
+
+    const heartsBarChildren = Array.from(heartsBarElement.children);
+    heartsBarChildren.forEach((childElement) => {
+        if (childElement === heartCountElement || childElement === heartIconsContainerElement) {
+            return;
+        }
+
+        if (childElement.classList && childElement.classList.contains(HeartClassName.HEART)) {
+            heartIconsContainerElement.appendChild(childElement);
+        }
+    });
+
+    return { heartCountElement, heartIconsContainerElement };
+}
+
+function updateHeartCountElement(heartCountElement, heartCountText) {
+    heartCountElement.textContent = heartCountText;
+}
+
+function appendHeartElements(heartIconsContainerElement, totalHearts) {
+    heartIconsContainerElement.innerHTML = TextContent.EMPTY;
     for (let heartIndex = 0; heartIndex < totalHearts; heartIndex += 1) {
         const heartElement = document.createElement(ElementTagName.SPAN);
         heartElement.className = HeartClassName.HEART;
         heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
         heartElement.textContent = HeartSymbol;
-        heartsBarElement.appendChild(heartElement);
+        heartIconsContainerElement.appendChild(heartElement);
     }
 }
 
-function appendGainHearts(heartsBarElement, heartsToAdd) {
+function appendGainHearts(heartIconsContainerElement, heartsToAdd) {
     for (let heartGainIndex = 0; heartGainIndex < heartsToAdd; heartGainIndex += 1) {
         const heartElement = document.createElement(ElementTagName.SPAN);
         heartElement.className = HeartClassName.HEART_GAIN;
         heartElement.setAttribute(AttributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
         heartElement.textContent = HeartSymbol;
-        heartsBarElement.appendChild(heartElement);
+        heartIconsContainerElement.appendChild(heartElement);
     }
 }
 
-function removeHeartElements(heartsBarElement, heartsToRemove) {
+function removeHeartElements(heartIconsContainerElement, heartsToRemove) {
     for (let removalIndex = 0; removalIndex < heartsToRemove; removalIndex += 1) {
-        const heartElement = heartsBarElement.querySelector(HeartSelector.HEART);
+        const heartElement = heartIconsContainerElement.querySelector(HeartSelector.HEART);
         if (!heartElement) {
             return;
         }
-        heartsBarElement.removeChild(heartElement);
+        heartIconsContainerElement.removeChild(heartElement);
     }
 }
 
@@ -70,27 +121,32 @@ export function renderHearts(count, options = {}) {
         return;
     }
 
+    const { heartCountElement, heartIconsContainerElement } = ensureHeartsBarChildren(heartsBarElement);
+
     const previousCount = parseInt(
-        heartsBarElement.getAttribute(AttributeName.DATA_COUNT) || "0",
+        heartsBarElement.getAttribute(AttributeName.DATA_COUNT) || TextContent.ZERO,
         NumericBase.DECIMAL
     );
     const totalHearts = Math.max(0, Math.floor(count || 0));
+    const heartCountText = String(totalHearts);
 
     if (!animate || previousCount === 0) {
-        appendHeartElements(heartsBarElement, totalHearts);
-        setMetadataAttributes(heartsBarElement, totalHearts);
+        appendHeartElements(heartIconsContainerElement, totalHearts);
+        updateHeartCountElement(heartCountElement, heartCountText);
+        setMetadataAttributes(heartsBarElement, totalHearts, heartCountText);
         return;
     }
 
-    const delta = totalHearts - previousCount;
-    if (delta > 0) {
-        appendGainHearts(heartsBarElement, delta);
-    } else if (delta < 0) {
-        const heartsToRemove = Math.min(previousCount, -delta);
-        removeHeartElements(heartsBarElement, heartsToRemove);
+    const heartCountDelta = totalHearts - previousCount;
+    if (heartCountDelta > 0) {
+        appendGainHearts(heartIconsContainerElement, heartCountDelta);
+    } else if (heartCountDelta < 0) {
+        const heartsToRemove = Math.min(previousCount, -heartCountDelta);
+        removeHeartElements(heartIconsContainerElement, heartsToRemove);
     }
 
-    setMetadataAttributes(heartsBarElement, totalHearts);
+    updateHeartCountElement(heartCountElement, heartCountText);
+    setMetadataAttributes(heartsBarElement, totalHearts, heartCountText);
 }
 
 export function animateHeartGainFromReveal() {

--- a/index.html
+++ b/index.html
@@ -190,6 +190,26 @@
             box-shadow: 2px 2px 0 #000;
         }
 
+        .heart-count {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 2ch;
+            padding: 2px 8px;
+            border-radius: 999px;
+            font-weight: 900;
+            font-variant-numeric: tabular-nums;
+            color: var(--primary);
+            background: rgba(255, 77, 109, 0.16);
+            box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
+        }
+
+        .heart-icons {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+        }
+
         .heart {
             display: inline-block;
             transform-origin: center;
@@ -647,7 +667,10 @@
         <h1>Allergy Wheel</h1>
     </div>
     <div class="header-right">
-        <div aria-live="polite" class="hearts" id="hearts-bar" title="Hearts"></div>
+        <div aria-live="polite" class="hearts" data-count="0" id="hearts-bar" aria-label="0 hearts" title="0 hearts">
+            <span class="heart-count">0</span>
+            <span aria-hidden="true" class="heart-icons"></span>
+        </div>
         <button class="ghost" id="fs">Full Screen</button>
         <button type="button" class="ghost" id="mute" aria-pressed="false" aria-label="Mute audio">Mute</button>
     </div>


### PR DESCRIPTION
## Summary
- render a persistent heart count element alongside the icons and keep aria metadata in sync when totals change
- update the header markup and styles to display the numeric counter next to the animated hearts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caf77851708327a4f4a18717cfa926