### PR TITLE
Add menu navigation and dish catalog view

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -2,7 +2,8 @@
 
 export const ScreenName = Object.freeze({
     ALLERGY: "allergy",
-    WHEEL: "wheel"
+    WHEEL: "wheel",
+    MENU: "menu"
 });
 
 
@@ -61,7 +62,9 @@ export const ControlElementId = Object.freeze({
     RESTART_BUTTON: "restart",
     AVATAR_TOGGLE: "avatar-toggle",
     AVATAR_MENU: "avatar-menu",
-    ALLERGY_TITLE: "allergy-title"
+    ALLERGY_TITLE: "allergy-title",
+    NAV_GAME_BUTTON: "nav-game",
+    NAV_MENU_BUTTON: "nav-menu"
 });
 
 const AvatarOptionClassName = "avatar-option";
@@ -98,6 +101,16 @@ export const ResultCardElementId = Object.freeze({
     FACE_SVG: "face",
     GAME_OVER_SECTION: ControlElementId.GAME_OVER_SECTION,
     WIN_RESTART_BUTTON: "win-restart"
+});
+
+export const ScreenElementId = Object.freeze({
+    ALLERGY: "screen-allergy",
+    WHEEL: "screen-wheel",
+    MENU: "screen-menu"
+});
+
+export const MenuElementId = Object.freeze({
+    TABLE_BODY: "menu-table-body"
 });
 
 export const DocumentElementId = Object.freeze({

--- a/index.html
+++ b/index.html
@@ -77,8 +77,10 @@
         }
 
         header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
-        .header-left { display: flex; align-items: center; gap: 14px; }
+        .header-left { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
         .header-right { display: flex; align-items: center; gap: 12px; }
+        .header-nav { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .header-nav .ghost { min-width: 80px; text-align: center; }
 
         .avatar-menu-wrapper { position: relative; }
 
@@ -576,9 +578,105 @@
         }
 
         /* Exclusive screens */
-        #screen-allergy, #screen-wheel { display: none }
+        #screen-allergy, #screen-wheel, #screen-menu { display: none }
         body[data-screen="allergy"] #screen-allergy { display: grid }
         body[data-screen="wheel"] #screen-wheel { display: grid }
+        body[data-screen="menu"] #screen-menu { display: block }
+
+        #screen-menu {
+            padding: clamp(18px, 4vw, 46px);
+        }
+
+        .menu-card {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: var(--card);
+            border-radius: 28px;
+            border: 4px solid #000;
+            box-shadow: var(--shadow);
+            padding: clamp(18px, 3.6vw, 40px);
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .menu-card__header { display: flex; flex-direction: column; gap: 8px; }
+
+        .menu-table-wrapper {
+            border-radius: 22px;
+            border: 3px solid #000;
+            overflow: hidden;
+        }
+
+        .menu-table {
+            width: 100%;
+            border-collapse: separate;
+            border-spacing: 0;
+            background: #fffaf1;
+        }
+
+        .menu-table thead th {
+            background: #ffdfe9;
+            padding: 16px;
+            font-size: clamp(13px, 1.6vw, 18px);
+            text-align: left;
+            border-bottom: 3px solid #000;
+            text-transform: uppercase;
+            letter-spacing: 0.6px;
+        }
+
+        .menu-table tbody tr:nth-child(odd) { background: #fff; }
+        .menu-table tbody tr:nth-child(even) { background: #fff5f9; }
+
+        .menu-table tbody td {
+            padding: clamp(14px, 2.4vw, 22px);
+            border-bottom: 2px solid #ffd6e3;
+            vertical-align: top;
+        }
+
+        .menu-table tbody tr:last-child td { border-bottom: none; }
+
+        .menu-dish-heading {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            font-weight: 900;
+            font-size: clamp(18px, 2.4vw, 26px);
+        }
+
+        .menu-dish-title {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .menu-ingredients { margin-top: 0; }
+        .menu-ingredients .ingredient { margin: 4px 6px 4px 0; }
+
+        .menu-cuisine-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-weight: 800;
+            background: #ffe08a;
+            border: 2px solid #000;
+            border-radius: 14px;
+            padding: 8px 12px;
+        }
+
+        .menu-narrative {
+            margin: 0;
+            font-weight: 600;
+            line-height: 1.5;
+        }
+
+        @media (max-width: 720px) {
+            #screen-menu { padding: 18px; }
+            .menu-card { padding: 18px; }
+            .menu-table-wrapper { border-radius: 18px; }
+            .menu-table thead { position: sticky; top: 0; z-index: 1; }
+            .menu-table tbody td { display: block; }
+        }
 
         /* Reveal overlay only on wheel screen */
         #reveal {
@@ -665,6 +763,24 @@
             </div>
         </div>
         <h1>Allergy Wheel</h1>
+        <div aria-label="Select a view" class="header-nav" role="group">
+            <button
+                aria-pressed="true"
+                class="ghost"
+                id="nav-game"
+                type="button"
+            >
+                Game
+            </button>
+            <button
+                aria-pressed="false"
+                class="ghost"
+                id="nav-menu"
+                type="button"
+            >
+                Menu
+            </button>
+        </div>
     </div>
     <div class="header-right">
         <div aria-live="polite" class="hearts" data-count="0" id="hearts-bar" aria-label="0 hearts" title="0 hearts">
@@ -715,6 +831,29 @@
     </div>
     <div class="status">Allergens: <span id="sel-badges"></span></div>
 </main>
+
+<!-- Menu -->
+<section aria-hidden="true" aria-labelledby="menu-title" id="screen-menu">
+    <div class="menu-card">
+        <div class="menu-card__header">
+            <h2 class="title" id="menu-title">Global Allergy-Friendly Menu</h2>
+            <p class="muted">Browse every dish from the wheel with its colorful story.</p>
+        </div>
+        <div class="menu-table-wrapper">
+            <table aria-describedby="menu-title" class="menu-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Dish</th>
+                        <th scope="col">Ingredients</th>
+                        <th scope="col">Cuisine</th>
+                        <th scope="col">Story</th>
+                    </tr>
+                </thead>
+                <tbody id="menu-table-body"></tbody>
+            </table>
+        </div>
+    </div>
+</section>
 
 <!-- Reveal -->
 <section aria-hidden="true" aria-labelledby="dish-title" aria-modal="true" id="reveal" role="dialog">

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,290 @@
+import { ScreenName } from "./constants.js";
+
+const TextContent = Object.freeze({
+    EMPTY: ""
+});
+
+const HtmlTagName = Object.freeze({
+    TR: "tr",
+    TD: "td",
+    DIV: "div",
+    SPAN: "span",
+    P: "p"
+});
+
+const ClassName = Object.freeze({
+    ROW: "menu-row",
+    CELL_DISH: "menu-cell menu-cell--dish",
+    CELL_INGREDIENTS: "menu-cell menu-cell--ingredients",
+    CELL_CUISINE: "menu-cell menu-cell--cuisine",
+    CELL_NARRATIVE: "menu-cell menu-cell--narrative",
+    DISH_HEADING: "menu-dish-heading",
+    DISH_TITLE: "menu-dish-title",
+    INGREDIENTS_CONTAINER: "ingredients menu-ingredients",
+    INGREDIENT: "ingredient",
+    INGREDIENT_BAD: "bad",
+    EMOJI_LARGE: "emoji-large",
+    CUISINE_BADGE: "menu-cuisine-badge",
+    NARRATIVE: "menu-narrative"
+});
+
+const ValueType = Object.freeze({
+    FUNCTION: typeof Function
+});
+
+function normalizeToMap(candidate) {
+    if (candidate instanceof Map) {
+        return candidate;
+    }
+    if (!candidate) {
+        return new Map();
+    }
+    return new Map(candidate);
+}
+
+function normalizeToArray(candidate) {
+    if (Array.isArray(candidate)) {
+        return candidate.slice();
+    }
+    if (candidate && typeof candidate[Symbol.iterator] === ValueType.FUNCTION) {
+        return Array.from(candidate);
+    }
+    return [];
+}
+
+export class MenuView {
+    #documentReference;
+
+    #menuTableBodyElement;
+
+    #dishesCatalog = [];
+
+    #normalizationEngine = null;
+
+    #ingredientEmojiByName = new Map();
+
+    #cuisineToFlagMap = new Map();
+
+    #emojiByTokenMap = new Map();
+
+    #selectedAllergenToken = null;
+
+    #selectedAllergenLabel = TextContent.EMPTY;
+
+    constructor({
+        documentReference = document,
+        menuTableBodyElement
+    } = {}) {
+        this.#documentReference = documentReference;
+        this.#menuTableBodyElement = menuTableBodyElement || null;
+    }
+
+    updateDataDependencies({
+        dishesCatalog,
+        normalizationEngine,
+        ingredientEmojiByName,
+        cuisineToFlagMap,
+        allergensCatalog
+    } = {}) {
+        if (Array.isArray(dishesCatalog)) {
+            this.#dishesCatalog = dishesCatalog.slice();
+        }
+        if (normalizationEngine) {
+            this.#normalizationEngine = normalizationEngine;
+        }
+        if (ingredientEmojiByName) {
+            this.#ingredientEmojiByName = normalizeToMap(ingredientEmojiByName);
+        }
+        if (cuisineToFlagMap) {
+            this.#cuisineToFlagMap = normalizeToMap(cuisineToFlagMap);
+        }
+        if (Array.isArray(allergensCatalog)) {
+            this.#emojiByTokenMap = this.#buildEmojiByTokenMap(allergensCatalog);
+        }
+    }
+
+    updateSelectedAllergen({ token, label } = {}) {
+        this.#selectedAllergenToken = token || null;
+        this.#selectedAllergenLabel = label || TextContent.EMPTY;
+        this.renderMenu();
+    }
+
+    renderMenu() {
+        if (!this.#menuTableBodyElement) {
+            return;
+        }
+
+        this.#menuTableBodyElement.textContent = TextContent.EMPTY;
+
+        for (const dishRecord of this.#dishesCatalog) {
+            if (!dishRecord) {
+                continue;
+            }
+            const rowElement = this.#documentReference.createElement(HtmlTagName.TR);
+            rowElement.className = ClassName.ROW;
+
+            rowElement.appendChild(this.#createDishCell(dishRecord));
+            rowElement.appendChild(this.#createIngredientsCell(dishRecord));
+            rowElement.appendChild(this.#createCuisineCell(dishRecord));
+            rowElement.appendChild(this.#createNarrativeCell(dishRecord));
+
+            this.#menuTableBodyElement.appendChild(rowElement);
+        }
+    }
+
+    getSelectedAllergen() {
+        return {
+            token: this.#selectedAllergenToken,
+            label: this.#selectedAllergenLabel
+        };
+    }
+
+    #createDishCell(dishRecord) {
+        const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
+        cellElement.className = ClassName.CELL_DISH;
+
+        const headingElement = this.#documentReference.createElement(HtmlTagName.DIV);
+        headingElement.className = ClassName.DISH_HEADING;
+
+        const emojiSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+        emojiSpan.className = ClassName.EMOJI_LARGE;
+        emojiSpan.textContent = String(dishRecord.emoji || TextContent.EMPTY);
+
+        const titleElement = this.#documentReference.createElement(HtmlTagName.DIV);
+        titleElement.className = ClassName.DISH_TITLE;
+        const nameText = dishRecord.name || dishRecord.title || dishRecord.id || TextContent.EMPTY;
+        titleElement.textContent = nameText;
+
+        if (emojiSpan.textContent) {
+            headingElement.appendChild(emojiSpan);
+        }
+        headingElement.appendChild(titleElement);
+        cellElement.appendChild(headingElement);
+
+        return cellElement;
+    }
+
+    #createIngredientsCell(dishRecord) {
+        const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
+        cellElement.className = ClassName.CELL_INGREDIENTS;
+
+        const ingredientsContainer = this.#documentReference.createElement(HtmlTagName.DIV);
+        ingredientsContainer.className = ClassName.INGREDIENTS_CONTAINER;
+
+        const ingredientList = normalizeToArray(dishRecord.ingredients);
+        for (const ingredientName of ingredientList) {
+            const ingredientChip = this.#createIngredientChip(ingredientName);
+            ingredientsContainer.appendChild(ingredientChip);
+        }
+
+        cellElement.appendChild(ingredientsContainer);
+        return cellElement;
+    }
+
+    #createCuisineCell(dishRecord) {
+        const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
+        cellElement.className = ClassName.CELL_CUISINE;
+
+        const badgeElement = this.#documentReference.createElement(HtmlTagName.SPAN);
+        badgeElement.className = ClassName.CUISINE_BADGE;
+
+        const cuisineName = String(dishRecord.cuisine || TextContent.EMPTY).trim();
+        const cuisineFlag = this.#resolveCuisineFlag(cuisineName);
+
+        if (cuisineFlag) {
+            const flagSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+            flagSpan.className = ClassName.EMOJI_LARGE;
+            flagSpan.textContent = cuisineFlag;
+            badgeElement.appendChild(flagSpan);
+        }
+
+        const cuisineTextSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+        cuisineTextSpan.textContent = cuisineName;
+        badgeElement.appendChild(cuisineTextSpan);
+
+        cellElement.appendChild(badgeElement);
+        return cellElement;
+    }
+
+    #createNarrativeCell(dishRecord) {
+        const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
+        cellElement.className = ClassName.CELL_NARRATIVE;
+
+        const paragraphElement = this.#documentReference.createElement(HtmlTagName.P);
+        paragraphElement.className = ClassName.NARRATIVE;
+        paragraphElement.textContent = String(dishRecord.narrative || TextContent.EMPTY);
+
+        cellElement.appendChild(paragraphElement);
+        return cellElement;
+    }
+
+    #createIngredientChip(ingredientName) {
+        const chipElement = this.#documentReference.createElement(HtmlTagName.SPAN);
+        chipElement.className = ClassName.INGREDIENT;
+
+        const ingredientText = String(ingredientName || TextContent.EMPTY);
+        const normalizedIngredientName = ingredientText.trim().toLowerCase();
+
+        const tokensForIngredient = this.#normalizationEngine
+            && typeof this.#normalizationEngine.tokensForIngredient === ValueType.FUNCTION
+                ? this.#normalizationEngine.tokensForIngredient(ingredientText)
+                : new Set();
+
+        let ingredientEmoji = this.#ingredientEmojiByName.get(normalizedIngredientName) || TextContent.EMPTY;
+        if (!ingredientEmoji) {
+            for (const allergenToken of tokensForIngredient || []) {
+                const emojiFromToken = this.#emojiByTokenMap.get(allergenToken);
+                if (emojiFromToken) {
+                    ingredientEmoji = emojiFromToken;
+                    break;
+                }
+            }
+        }
+
+        if (this.#selectedAllergenToken && tokensForIngredient && tokensForIngredient.has(this.#selectedAllergenToken)) {
+            chipElement.classList.add(ClassName.INGREDIENT_BAD);
+            if (!ingredientEmoji) {
+                ingredientEmoji = this.#emojiByTokenMap.get(this.#selectedAllergenToken) || TextContent.EMPTY;
+            }
+        }
+
+        const textSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+        textSpan.textContent = ingredientText;
+        chipElement.appendChild(textSpan);
+
+        if (ingredientEmoji) {
+            const emojiSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+            emojiSpan.className = ClassName.EMOJI_LARGE;
+            emojiSpan.textContent = ingredientEmoji;
+            chipElement.appendChild(emojiSpan);
+        }
+
+        return chipElement;
+    }
+
+    #resolveCuisineFlag(cuisineName) {
+        if (!cuisineName || !this.#cuisineToFlagMap) {
+            return TextContent.EMPTY;
+        }
+        const normalizedKey = String(cuisineName).trim().toLowerCase();
+        return this.#cuisineToFlagMap.get(normalizedKey) || TextContent.EMPTY;
+    }
+
+    #buildEmojiByTokenMap(allergensCatalog) {
+        const emojiMap = new Map();
+        for (const allergenRecord of allergensCatalog) {
+            if (!allergenRecord || !allergenRecord.token) {
+                continue;
+            }
+            const allergenEmoji = allergenRecord.emoji || TextContent.EMPTY;
+            if (allergenEmoji) {
+                emojiMap.set(allergenRecord.token, allergenEmoji);
+            }
+        }
+        return emojiMap;
+    }
+}
+
+export function isMenuScreen(screenName) {
+    return screenName === ScreenName.MENU;
+}

--- a/navigation.js
+++ b/navigation.js
@@ -1,0 +1,116 @@
+import {
+    ScreenName,
+    AttributeName,
+    AttributeBooleanValue,
+    ControlElementId
+} from "./constants.js";
+
+const TextContent = Object.freeze({
+    EMPTY: ""
+});
+
+const ValueType = Object.freeze({
+    FUNCTION: typeof Function
+});
+
+export class NavigationController {
+    #documentReference;
+
+    #controlElementIdMap;
+
+    #attributeNameMap;
+
+    #onScreenChange;
+
+    #gameButtonElement = null;
+
+    #menuButtonElement = null;
+
+    constructor({
+        documentReference = document,
+        controlElementIdMap = ControlElementId,
+        attributeNameMap = AttributeName,
+        onScreenChange
+    } = {}) {
+        this.#documentReference = documentReference;
+        this.#controlElementIdMap = controlElementIdMap;
+        this.#attributeNameMap = attributeNameMap;
+        this.#onScreenChange = typeof onScreenChange === ValueType.FUNCTION ? onScreenChange : null;
+    }
+
+    initialize() {
+        if (!this.#documentReference || !this.#controlElementIdMap) {
+            return;
+        }
+
+        this.#gameButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.NAV_GAME_BUTTON
+        );
+        this.#menuButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.NAV_MENU_BUTTON
+        );
+
+        this.#wireNavigationButton(this.#gameButtonElement, ScreenName.ALLERGY);
+        this.#wireNavigationButton(this.#menuButtonElement, ScreenName.MENU);
+    }
+
+    updateActiveScreen(screenName) {
+        const activeCategory = this.#mapScreenToCategory(screenName);
+        const ariaPressedAttribute = this.#attributeNameMap?.ARIA_PRESSED;
+        const pressedTrue = AttributeBooleanValue.TRUE;
+        const pressedFalse = AttributeBooleanValue.FALSE;
+
+        if (this.#gameButtonElement && ariaPressedAttribute) {
+            const shouldPressGame = activeCategory !== ScreenName.MENU;
+            this.#gameButtonElement.setAttribute(
+                ariaPressedAttribute,
+                shouldPressGame ? pressedTrue : pressedFalse
+            );
+        }
+
+        if (this.#menuButtonElement && ariaPressedAttribute) {
+            const shouldPressMenu = activeCategory === ScreenName.MENU;
+            this.#menuButtonElement.setAttribute(
+                ariaPressedAttribute,
+                shouldPressMenu ? pressedTrue : pressedFalse
+            );
+        }
+    }
+
+    #wireNavigationButton(buttonElement, targetScreenName) {
+        if (!buttonElement) {
+            return;
+        }
+        buttonElement.addEventListener("click", () => {
+            this.updateActiveScreen(targetScreenName);
+            if (this.#onScreenChange) {
+                this.#onScreenChange(targetScreenName);
+            }
+        });
+    }
+
+    #mapScreenToCategory(screenName) {
+        if (screenName === ScreenName.MENU) {
+            return ScreenName.MENU;
+        }
+        if (screenName === ScreenName.WHEEL || screenName === ScreenName.ALLERGY) {
+            return ScreenName.ALLERGY;
+        }
+        return ScreenName.ALLERGY;
+    }
+}
+
+export function resolveInitialNavState() {
+    const bodyElement = document.body;
+    if (!bodyElement) {
+        return ScreenName.ALLERGY;
+    }
+    const dataScreenAttribute = AttributeName.DATA_SCREEN || TextContent.EMPTY;
+    const activeScreen = dataScreenAttribute
+        ? bodyElement.getAttribute(dataScreenAttribute) || TextContent.EMPTY
+        : TextContent.EMPTY;
+    if (activeScreen === ScreenName.MENU) {
+        return ScreenName.MENU;
+    }
+    return ScreenName.ALLERGY;
+}

--- a/tests/integration/gameController.integration.test.js
+++ b/tests/integration/gameController.integration.test.js
@@ -146,6 +146,14 @@ function createHeartsPresenterStub() {
   };
 }
 
+function createMenuPresenterStub() {
+  return {
+    updateDataDependencies: jest.fn(),
+    renderMenu: jest.fn(),
+    updateSelectedAllergen: jest.fn()
+  };
+}
+
 function createAudioPresenterStub({ stateManager } = {}) {
   const effect = {
     playTick: jest.fn(),
@@ -348,6 +356,7 @@ describe("GameController integration", () => {
       });
       const heartsPresenter = createHeartsPresenterStub();
       const audioPresenter = createAudioPresenterStub({ stateManager });
+      const menuPresenter = createMenuPresenterStub();
       const uiPresenter = createUiPresenterStub();
       const normalizationFactory = createNormalizationFactoryStub();
       const randomPicker = createPickRandomUniqueStub();
@@ -373,6 +382,7 @@ describe("GameController integration", () => {
         revealCardPresenter,
         heartsPresenter,
         audioPresenter,
+        menuPresenter,
         uiPresenter,
         dataLoader,
         createNormalizationEngine: normalizationFactory,
@@ -385,6 +395,10 @@ describe("GameController integration", () => {
       expect(dataLoader.loadJson).toHaveBeenCalledTimes(5);
       expect(firstCardPresenter.renderAllergens).toHaveBeenCalledWith(expect.any(Array));
       expect(wheelStub.registerSpinCallbacks).toHaveBeenCalled();
+      expect(menuPresenter.updateDataDependencies).toHaveBeenCalledWith(
+        expect.objectContaining({ dishesCatalog: expect.any(Array) })
+      );
+      expect(menuPresenter.renderMenu).toHaveBeenCalled();
 
       stateManager.setSelectedAllergen({ token: TestAllergen.TOKEN, label: TestAllergen.LABEL });
       stateManager.setWheelCandidates({
@@ -431,6 +445,7 @@ describe("GameController integration", () => {
     });
     const heartsPresenter = createHeartsPresenterStub();
     const audioPresenter = createAudioPresenterStub({ stateManager });
+    const menuPresenter = createMenuPresenterStub();
     const uiPresenter = createUiPresenterStub();
     const normalizationFactory = createNormalizationFactoryStub();
     const randomPicker = createPickRandomUniqueStub();
@@ -456,6 +471,7 @@ describe("GameController integration", () => {
       revealCardPresenter,
       heartsPresenter,
       audioPresenter,
+      menuPresenter,
       uiPresenter,
       dataLoader,
       createNormalizationEngine: normalizationFactory,
@@ -505,6 +521,7 @@ describe("GameController wheel allergen distribution", () => {
       });
       const heartsPresenter = createHeartsPresenterStub();
       const audioPresenter = createAudioPresenterStub({ stateManager });
+      const menuPresenter = createMenuPresenterStub();
       const uiPresenter = createUiPresenterStub();
       const normalizationFactory = createNormalizationFactoryStub();
       const randomPicker = createPickRandomUniqueStub();
@@ -534,6 +551,7 @@ describe("GameController wheel allergen distribution", () => {
         revealCardPresenter,
         heartsPresenter,
         audioPresenter,
+        menuPresenter,
         uiPresenter,
         dataLoader,
         createNormalizationEngine: normalizationFactory,

--- a/tests/integration/navigationMenu.integration.test.js
+++ b/tests/integration/navigationMenu.integration.test.js
@@ -1,0 +1,232 @@
+import { jest } from "@jest/globals";
+import { NavigationController } from "../../navigation.js";
+import { MenuView } from "../../menu.js";
+import {
+  ControlElementId,
+  AttributeName,
+  AttributeBooleanValue,
+  ScreenName,
+  MenuElementId
+} from "../../constants.js";
+import { NormalizationEngine } from "../../utils.js";
+
+const HtmlTagName = Object.freeze({
+  BUTTON: "button",
+  TABLE: "table",
+  TBODY: "tbody"
+});
+
+const NavigationScenarioDescription = Object.freeze({
+  GAME_BUTTON: "clicking the game button requests the allergy screen",
+  MENU_BUTTON: "clicking the menu button requests the menu screen"
+});
+
+const NavigationActiveStateScenario = Object.freeze({
+  MENU_ACTIVE: "marks the menu button as pressed when menu screen is active",
+  GAME_ACTIVE: "marks the game button as pressed when allergy screen is active",
+  WHEEL_ACTIVE: "marks the game button as pressed when wheel screen is active"
+});
+
+const MenuRenderingScenarioDescription = Object.freeze({
+  NO_SELECTION: "renders dishes without highlights when no allergen is selected",
+  WITH_SELECTION: "highlights allergen ingredients when an allergen is selected"
+});
+
+const NavigationClickScenarios = Object.freeze([
+  Object.freeze({
+    description: NavigationScenarioDescription.GAME_BUTTON,
+    buttonId: ControlElementId.NAV_GAME_BUTTON,
+    expectedScreen: ScreenName.ALLERGY
+  }),
+  Object.freeze({
+    description: NavigationScenarioDescription.MENU_BUTTON,
+    buttonId: ControlElementId.NAV_MENU_BUTTON,
+    expectedScreen: ScreenName.MENU
+  })
+]);
+
+const NavigationActiveStateScenarios = Object.freeze([
+  Object.freeze({
+    description: NavigationActiveStateScenario.MENU_ACTIVE,
+    targetScreen: ScreenName.MENU,
+    expectedGameState: AttributeBooleanValue.FALSE,
+    expectedMenuState: AttributeBooleanValue.TRUE
+  }),
+  Object.freeze({
+    description: NavigationActiveStateScenario.GAME_ACTIVE,
+    targetScreen: ScreenName.ALLERGY,
+    expectedGameState: AttributeBooleanValue.TRUE,
+    expectedMenuState: AttributeBooleanValue.FALSE
+  }),
+  Object.freeze({
+    description: NavigationActiveStateScenario.WHEEL_ACTIVE,
+    targetScreen: ScreenName.WHEEL,
+    expectedGameState: AttributeBooleanValue.TRUE,
+    expectedMenuState: AttributeBooleanValue.FALSE
+  })
+]);
+
+const MenuRenderingScenarios = Object.freeze([
+  Object.freeze({
+    description: MenuRenderingScenarioDescription.NO_SELECTION,
+    selectedAllergen: null,
+    expectedHighlightedIngredients: []
+  }),
+  Object.freeze({
+    description: MenuRenderingScenarioDescription.WITH_SELECTION,
+    selectedAllergen: { token: "peanut", label: "Peanut" },
+    expectedHighlightedIngredients: ["Peanuts"]
+  })
+]);
+
+const SampleDishes = Object.freeze([
+  Object.freeze({
+    id: "dish-peanut-noodles",
+    name: "Peanut Noodles",
+    emoji: "🍜",
+    cuisine: "Thai",
+    ingredients: ["Peanuts", "Rice Noodles"],
+    narrative: "A friendly noodle bowl."
+  }),
+  Object.freeze({
+    id: "dish-fruit-salad",
+    name: "Fruit Salad",
+    emoji: "🥗",
+    cuisine: "American",
+    ingredients: ["Strawberries", "Blueberries"],
+    narrative: "A colorful fruit mix."
+  })
+]);
+
+const IngredientEmojiEntries = Object.freeze([
+  Object.freeze(["peanuts", "🥜"]),
+  Object.freeze(["rice noodles", "🍜"]),
+  Object.freeze(["strawberries", "🍓"]),
+  Object.freeze(["blueberries", "🔵"])
+]);
+
+const CuisineFlagEntries = Object.freeze([
+  Object.freeze(["thai", "🇹🇭"]),
+  Object.freeze(["american", "🇺🇸"])
+]);
+
+const AllergenCatalog = Object.freeze([
+  Object.freeze({ token: "peanut", label: "Peanut", emoji: "🥜" })
+]);
+
+const NormalizationRules = Object.freeze([
+  Object.freeze({ pattern: "peanut", token: "peanut", flags: "i" })
+]);
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("NavigationController", () => {
+  test.each(NavigationClickScenarios)("%s", ({ buttonId, expectedScreen }) => {
+    document.body.innerHTML = `
+      <div>
+        <${HtmlTagName.BUTTON} id="${ControlElementId.NAV_GAME_BUTTON}" aria-pressed="true">Game</${HtmlTagName.BUTTON}>
+        <${HtmlTagName.BUTTON} id="${ControlElementId.NAV_MENU_BUTTON}" aria-pressed="false">Menu</${HtmlTagName.BUTTON}>
+      </div>
+    `;
+
+    const onScreenChange = jest.fn();
+    const navigationController = new NavigationController({
+      documentReference: document,
+      controlElementIdMap: ControlElementId,
+      attributeNameMap: AttributeName,
+      onScreenChange
+    });
+
+    navigationController.initialize();
+
+    const targetButton = document.getElementById(buttonId);
+    targetButton.click();
+
+    expect(onScreenChange).toHaveBeenCalledWith(expectedScreen);
+  });
+
+  test.each(NavigationActiveStateScenarios)("%s", ({
+    targetScreen,
+    expectedGameState,
+    expectedMenuState
+  }) => {
+    document.body.innerHTML = `
+      <div>
+        <${HtmlTagName.BUTTON} id="${ControlElementId.NAV_GAME_BUTTON}" aria-pressed="false">Game</${HtmlTagName.BUTTON}>
+        <${HtmlTagName.BUTTON} id="${ControlElementId.NAV_MENU_BUTTON}" aria-pressed="false">Menu</${HtmlTagName.BUTTON}>
+      </div>
+    `;
+
+    const navigationController = new NavigationController({
+      documentReference: document,
+      controlElementIdMap: ControlElementId,
+      attributeNameMap: AttributeName
+    });
+
+    navigationController.initialize();
+    navigationController.updateActiveScreen(targetScreen);
+
+    const gameButton = document.getElementById(ControlElementId.NAV_GAME_BUTTON);
+    const menuButton = document.getElementById(ControlElementId.NAV_MENU_BUTTON);
+
+    expect(gameButton.getAttribute(AttributeName.ARIA_PRESSED)).toBe(expectedGameState);
+    expect(menuButton.getAttribute(AttributeName.ARIA_PRESSED)).toBe(expectedMenuState);
+  });
+});
+
+describe("MenuView", () => {
+  test.each(MenuRenderingScenarios)("%s", ({ selectedAllergen, expectedHighlightedIngredients }) => {
+    document.body.innerHTML = `
+      <${HtmlTagName.TABLE}>
+        <${HtmlTagName.TBODY} id="${MenuElementId.TABLE_BODY}"></${HtmlTagName.TBODY}>
+      </${HtmlTagName.TABLE}>
+    `;
+
+    const menuTableBodyElement = document.getElementById(MenuElementId.TABLE_BODY);
+    const menuView = new MenuView({
+      documentReference: document,
+      menuTableBodyElement
+    });
+
+    const normalizationEngine = new NormalizationEngine(NormalizationRules);
+
+    menuView.updateDataDependencies({
+      dishesCatalog: SampleDishes,
+      normalizationEngine,
+      ingredientEmojiByName: new Map(IngredientEmojiEntries),
+      cuisineToFlagMap: new Map(CuisineFlagEntries),
+      allergensCatalog: AllergenCatalog
+    });
+
+    if (selectedAllergen) {
+      menuView.updateSelectedAllergen(selectedAllergen);
+    } else {
+      menuView.updateSelectedAllergen({});
+    }
+
+    const rowElements = menuTableBodyElement.querySelectorAll("tr");
+    expect(rowElements).toHaveLength(SampleDishes.length);
+
+    const firstRowText = rowElements[0].textContent;
+    expect(firstRowText).toContain(SampleDishes[0].name);
+    expect(firstRowText).toContain(SampleDishes[0].narrative);
+
+    const cuisineBadgeElement = rowElements[0].querySelector(".menu-cuisine-badge");
+    expect(cuisineBadgeElement.textContent).toContain(SampleDishes[0].cuisine);
+
+    const highlightedIngredients = Array.from(
+      menuTableBodyElement.querySelectorAll(".ingredient.bad")
+    );
+
+    expect(highlightedIngredients).toHaveLength(expectedHighlightedIngredients.length);
+    for (const ingredientName of expectedHighlightedIngredients) {
+      expect(
+        highlightedIngredients.some((ingredientElement) =>
+          ingredientElement.textContent.includes(ingredientName)
+        )
+      ).toBe(true);
+    }
+  });
+});

--- a/ui.js
+++ b/ui.js
@@ -3,8 +3,15 @@ import {
     ScreenName,
     AttributeName,
     AttributeBooleanValue,
-    ResultCardElementId
+    ResultCardElementId,
+    ScreenElementId
 } from "./constants.js";
+
+const ScreenElementEntries = Object.freeze([
+    Object.freeze([ScreenName.ALLERGY, ScreenElementId.ALLERGY]),
+    Object.freeze([ScreenName.WHEEL, ScreenElementId.WHEEL]),
+    Object.freeze([ScreenName.MENU, ScreenElementId.MENU])
+]);
 
 export function showScreen(screenName) {
     const bodyElement = document.body;
@@ -14,10 +21,28 @@ export function showScreen(screenName) {
 
     const revealElement = document.getElementById(ResultCardElementId.REVEAL_SECTION);
 
-    if (screenName === ScreenName.ALLERGY) {
-        bodyElement.setAttribute(AttributeName.DATA_SCREEN, ScreenName.ALLERGY);
-    } else if (screenName === ScreenName.WHEEL) {
-        bodyElement.setAttribute(AttributeName.DATA_SCREEN, ScreenName.WHEEL);
+    let resolvedScreenName = ScreenName.ALLERGY;
+    if (screenName === ScreenName.WHEEL) {
+        resolvedScreenName = ScreenName.WHEEL;
+    } else if (screenName === ScreenName.MENU) {
+        resolvedScreenName = ScreenName.MENU;
+    }
+
+    bodyElement.setAttribute(AttributeName.DATA_SCREEN, resolvedScreenName);
+
+    const ariaHiddenAttributeName = AttributeName.ARIA_HIDDEN;
+    if (ariaHiddenAttributeName) {
+        for (const [knownScreenName, elementId] of ScreenElementEntries) {
+            const screenElement = document.getElementById(elementId);
+            if (!screenElement) {
+                continue;
+            }
+            const isActiveScreen = knownScreenName === resolvedScreenName;
+            screenElement.setAttribute(
+                ariaHiddenAttributeName,
+                isActiveScreen ? AttributeBooleanValue.FALSE : AttributeBooleanValue.TRUE
+            );
+        }
     }
 
     if (revealElement) {


### PR DESCRIPTION
## Summary
- add navigation buttons and a menu table section to the main page so the menu view matches the wheel styling
- introduce a MenuView with supporting navigation controller wiring to toggle between game and menu screens and keep the table in sync with selections
- expand integration coverage for the menu data feed and add dedicated tests for navigation state and menu rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caff8026f08327b58affe6c73447e7