### PR TITLE
Add interactive menu filters with controller and tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ import { AllergenCard } from "./firstCard.js";
 import { ResultCard } from "./lastCard.js";
 import { renderHearts, animateHeartGainFromReveal, animateHeartLossAtHeartsBar } from "./hearts.js";
 import { MenuView } from "./menu.js";
+import { MenuFilterController } from "./menuFilters.js";
 import { NavigationController, resolveInitialNavState } from "./navigation.js";
 import {
     primeAudioOnFirstGesture as primeAudioOnFirstGestureEffect,
@@ -75,6 +76,15 @@ const menuPresenter = new MenuView({
     documentReference: document,
     menuTableBodyElement: document.getElementById(MenuElementId.TABLE_BODY)
 });
+
+const menuFilterController = new MenuFilterController({
+    documentReference: document,
+    menuPresenter,
+    controlElementIdMap: MenuElementId,
+    attributeNameMap: AttributeName
+});
+
+menuFilterController.initialize();
 
 const firstCardPresenter = new AllergenCard({
     listContainerElement: document.getElementById(FirstCardElementId.LIST_CONTAINER),

--- a/constants.js
+++ b/constants.js
@@ -110,7 +110,24 @@ export const ScreenElementId = Object.freeze({
 });
 
 export const MenuElementId = Object.freeze({
-    TABLE_BODY: "menu-table-body"
+    TABLE_BODY: "menu-table-body",
+    INGREDIENT_FILTER_TOGGLE: "menu-ingredient-filter-toggle",
+    INGREDIENT_FILTER_PANEL: "menu-ingredient-filter-panel",
+    INGREDIENT_FILTER_LIST: "menu-ingredient-filter-list",
+    INGREDIENT_FILTER_CLEAR: "menu-ingredient-filter-clear",
+    CUISINE_FILTER_TOGGLE: "menu-cuisine-filter-toggle",
+    CUISINE_FILTER_PANEL: "menu-cuisine-filter-panel",
+    CUISINE_FILTER_LIST: "menu-cuisine-filter-list",
+    CUISINE_FILTER_CLEAR: "menu-cuisine-filter-clear"
+});
+
+export const MenuFilterText = Object.freeze({
+    FILTER_LABEL: "Filter",
+    INGREDIENT_FILTER_ARIA_LABEL: "Filter ingredients",
+    CUISINE_FILTER_ARIA_LABEL: "Filter cuisines",
+    CLEAR_INGREDIENT_LABEL: "Clear ingredient filters",
+    CLEAR_CUISINE_LABEL: "Clear cuisine filters",
+    SELECT_ALL_LABEL: "Show all"
 });
 
 export const DocumentElementId = Object.freeze({

--- a/index.html
+++ b/index.html
@@ -626,40 +626,50 @@
         }
 
         .menu-header-cell {
+            position: relative;
             display: flex;
             align-items: center;
-            justify-content: space-between;
+            justify-content: flex-start;
             gap: 12px;
             flex-wrap: wrap;
         }
 
-        .menu-header-label {
-            font-weight: 800;
-            letter-spacing: 0.4px;
-        }
-
-        .menu-filter-control { position: relative; }
-
-        .menu-filter-button {
+        .menu-header-toggle {
             display: inline-flex;
             align-items: center;
-            gap: 6px;
-            background: #fff;
-            border: 2px solid #000;
-            border-radius: 999px;
-            padding: 6px 14px;
-            font-weight: 700;
-            font-size: clamp(12px, 1.4vw, 16px);
+            gap: 8px;
+            background: transparent;
+            border: 0;
+            padding: 0;
+            margin: 0;
+            font: inherit;
+            font-weight: 800;
+            letter-spacing: 0.4px;
+            color: inherit;
             cursor: pointer;
-            box-shadow: 2px 2px 0 #000;
-            transition: transform 150ms ease, box-shadow 150ms ease;
+            text-transform: uppercase;
+            transition: color 150ms ease;
         }
 
-        .menu-filter-button:hover,
-        .menu-filter-button:focus-visible {
-            transform: translateY(-1px);
-            box-shadow: 3px 3px 0 #000;
-            outline: none;
+        .menu-header-toggle::after {
+            content: "▾";
+            font-size: 0.8em;
+            transform: rotate(0deg);
+            transition: transform 160ms ease;
+        }
+
+        .menu-header-toggle[aria-expanded="true"]::after {
+            transform: rotate(180deg);
+        }
+
+        .menu-header-toggle:hover {
+            color: var(--primary);
+        }
+
+        .menu-header-toggle:focus-visible {
+            outline: 3px solid #000;
+            outline-offset: 3px;
+            border-radius: 8px;
         }
 
         .menu-filter-panel {
@@ -824,8 +834,7 @@
             .menu-table thead { position: sticky; top: 0; z-index: 1; }
             .menu-table tbody td { display: block; }
             .menu-header-cell { align-items: flex-start; }
-            .menu-filter-control { width: 100%; }
-            .menu-filter-button { width: 100%; justify-content: center; }
+            .menu-header-toggle { width: 100%; justify-content: space-between; }
             .menu-filter-panel {
                 position: relative;
                 right: auto;
@@ -1003,75 +1012,69 @@
                         <th scope="col">Dish</th>
                         <th scope="col">
                             <div class="menu-header-cell">
-                                <span class="menu-header-label">Ingredients</span>
-                                <div class="menu-filter-control">
-                                    <button
-                                        aria-controls="menu-ingredient-filter-panel"
-                                        aria-expanded="false"
-                                        aria-haspopup="true"
-                                        class="menu-filter-button"
-                                        id="menu-ingredient-filter-toggle"
-                                        type="button"
-                                    >
-                                        Filter
-                                    </button>
-                                    <div
-                                        aria-label="Filter ingredients"
-                                        class="menu-filter-panel"
-                                        hidden
-                                        id="menu-ingredient-filter-panel"
-                                        role="group"
-                                    >
-                                        <div class="menu-filter-header">
-                                            <p class="menu-filter-title">Filter by ingredient</p>
-                                            <button
-                                                aria-disabled="true"
-                                                class="menu-filter-clear"
-                                                id="menu-ingredient-filter-clear"
-                                                type="button"
-                                            >
-                                                Clear
-                                            </button>
-                                        </div>
-                                        <div class="menu-filter-list" id="menu-ingredient-filter-list"></div>
+                                <button
+                                    aria-controls="menu-ingredient-filter-panel"
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                    class="menu-header-toggle"
+                                    id="menu-ingredient-filter-toggle"
+                                    type="button"
+                                >
+                                    Ingredients
+                                </button>
+                                <div
+                                    aria-label="Filter ingredients"
+                                    class="menu-filter-panel"
+                                    hidden
+                                    id="menu-ingredient-filter-panel"
+                                    role="group"
+                                >
+                                    <div class="menu-filter-header">
+                                        <p class="menu-filter-title">Filter by ingredient</p>
+                                        <button
+                                            aria-disabled="true"
+                                            class="menu-filter-clear"
+                                            id="menu-ingredient-filter-clear"
+                                            type="button"
+                                        >
+                                            Clear
+                                        </button>
                                     </div>
+                                    <div class="menu-filter-list" id="menu-ingredient-filter-list"></div>
                                 </div>
                             </div>
                         </th>
                         <th scope="col">
                             <div class="menu-header-cell">
-                                <span class="menu-header-label">Cuisine</span>
-                                <div class="menu-filter-control">
-                                    <button
-                                        aria-controls="menu-cuisine-filter-panel"
-                                        aria-expanded="false"
-                                        aria-haspopup="true"
-                                        class="menu-filter-button"
-                                        id="menu-cuisine-filter-toggle"
-                                        type="button"
-                                    >
-                                        Filter
-                                    </button>
-                                    <div
-                                        aria-label="Filter cuisines"
-                                        class="menu-filter-panel"
-                                        hidden
-                                        id="menu-cuisine-filter-panel"
-                                        role="group"
-                                    >
-                                        <div class="menu-filter-header">
-                                            <p class="menu-filter-title">Filter by cuisine</p>
-                                            <button
-                                                aria-disabled="true"
-                                                class="menu-filter-clear"
-                                                id="menu-cuisine-filter-clear"
-                                                type="button"
-                                            >
-                                                Clear
-                                            </button>
-                                        </div>
-                                        <div class="menu-filter-list" id="menu-cuisine-filter-list"></div>
+                                <button
+                                    aria-controls="menu-cuisine-filter-panel"
+                                    aria-expanded="false"
+                                    aria-haspopup="true"
+                                    class="menu-header-toggle"
+                                    id="menu-cuisine-filter-toggle"
+                                    type="button"
+                                >
+                                    Cuisine
+                                </button>
+                                <div
+                                    aria-label="Filter cuisines"
+                                    class="menu-filter-panel"
+                                    hidden
+                                    id="menu-cuisine-filter-panel"
+                                    role="group"
+                                >
+                                    <div class="menu-filter-header">
+                                        <p class="menu-filter-title">Filter by cuisine</p>
+                                        <button
+                                            aria-disabled="true"
+                                            class="menu-filter-clear"
+                                            id="menu-cuisine-filter-clear"
+                                            type="button"
+                                        >
+                                            Clear
+                                        </button>
                                     </div>
+                                    <div class="menu-filter-list" id="menu-cuisine-filter-list"></div>
                                 </div>
                             </div>
                         </th>

--- a/index.html
+++ b/index.html
@@ -625,6 +625,153 @@
             letter-spacing: 0.6px;
         }
 
+        .menu-header-cell {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .menu-header-label {
+            font-weight: 800;
+            letter-spacing: 0.4px;
+        }
+
+        .menu-filter-control { position: relative; }
+
+        .menu-filter-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: #fff;
+            border: 2px solid #000;
+            border-radius: 999px;
+            padding: 6px 14px;
+            font-weight: 700;
+            font-size: clamp(12px, 1.4vw, 16px);
+            cursor: pointer;
+            box-shadow: 2px 2px 0 #000;
+            transition: transform 150ms ease, box-shadow 150ms ease;
+        }
+
+        .menu-filter-button:hover,
+        .menu-filter-button:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 3px 3px 0 #000;
+            outline: none;
+        }
+
+        .menu-filter-panel {
+            position: absolute;
+            top: calc(100% + 8px);
+            right: 0;
+            min-width: 240px;
+            max-width: 320px;
+            background: #fff;
+            border: 3px solid #000;
+            border-radius: 20px;
+            box-shadow: var(--shadow);
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            z-index: 5;
+        }
+
+        .menu-filter-panel[hidden] { display: none; }
+
+        .menu-filter-panel.is-open { display: flex; }
+
+        .menu-filter-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .menu-filter-title {
+            margin: 0;
+            font-weight: 800;
+            font-size: clamp(13px, 1.4vw, 16px);
+        }
+
+        .menu-filter-clear {
+            border: 0;
+            background: transparent;
+            font-weight: 700;
+            color: var(--primary);
+            cursor: pointer;
+            padding: 6px 12px;
+            border-radius: 999px;
+            transition: background 150ms ease, transform 150ms ease;
+        }
+
+        .menu-filter-clear[aria-disabled="true"],
+        .menu-filter-clear:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .menu-filter-clear:not([aria-disabled="true"]):hover,
+        .menu-filter-clear:not([aria-disabled="true"]):focus-visible {
+            background: rgba(255, 77, 109, 0.12);
+            outline: none;
+            transform: translateY(-1px);
+        }
+
+        .menu-filter-list {
+            display: grid;
+            gap: 8px;
+            max-height: 260px;
+            overflow-y: auto;
+        }
+
+        .menu-filter-option {
+            display: grid;
+            grid-template-columns: 22px 1fr;
+            align-items: center;
+            gap: 10px;
+            border: 2px solid #000;
+            border-radius: 14px;
+            padding: 8px 14px;
+            background: #fffaf1;
+            font-weight: 700;
+            cursor: pointer;
+            box-shadow: 2px 2px 0 #000;
+            transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+        }
+
+        .menu-filter-option:hover,
+        .menu-filter-option:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 3px 3px 0 #000;
+            background: #ffe7ee;
+            outline: none;
+        }
+
+        .menu-filter-option__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 0.85rem;
+            min-width: 18px;
+            color: var(--primary);
+        }
+
+        .menu-filter-option__label {
+            text-align: left;
+        }
+
+        .menu-filter-option:not(.is-selected) .menu-filter-option__icon { color: transparent; }
+
+        .menu-row--empty .menu-cell--empty {
+            text-align: center;
+            font-weight: 700;
+            color: var(--muted);
+            padding: 32px 16px;
+        }
+
         .menu-table tbody tr:nth-child(odd) { background: #fff; }
         .menu-table tbody tr:nth-child(even) { background: #fff5f9; }
 
@@ -676,6 +823,16 @@
             .menu-table-wrapper { border-radius: 18px; }
             .menu-table thead { position: sticky; top: 0; z-index: 1; }
             .menu-table tbody td { display: block; }
+            .menu-header-cell { align-items: flex-start; }
+            .menu-filter-control { width: 100%; }
+            .menu-filter-button { width: 100%; justify-content: center; }
+            .menu-filter-panel {
+                position: relative;
+                right: auto;
+                top: auto;
+                width: 100%;
+                margin-top: 8px;
+            }
         }
 
         /* Reveal overlay only on wheel screen */
@@ -844,8 +1001,80 @@
                 <thead>
                     <tr>
                         <th scope="col">Dish</th>
-                        <th scope="col">Ingredients</th>
-                        <th scope="col">Cuisine</th>
+                        <th scope="col">
+                            <div class="menu-header-cell">
+                                <span class="menu-header-label">Ingredients</span>
+                                <div class="menu-filter-control">
+                                    <button
+                                        aria-controls="menu-ingredient-filter-panel"
+                                        aria-expanded="false"
+                                        aria-haspopup="true"
+                                        class="menu-filter-button"
+                                        id="menu-ingredient-filter-toggle"
+                                        type="button"
+                                    >
+                                        Filter
+                                    </button>
+                                    <div
+                                        aria-label="Filter ingredients"
+                                        class="menu-filter-panel"
+                                        hidden
+                                        id="menu-ingredient-filter-panel"
+                                        role="group"
+                                    >
+                                        <div class="menu-filter-header">
+                                            <p class="menu-filter-title">Filter by ingredient</p>
+                                            <button
+                                                aria-disabled="true"
+                                                class="menu-filter-clear"
+                                                id="menu-ingredient-filter-clear"
+                                                type="button"
+                                            >
+                                                Clear
+                                            </button>
+                                        </div>
+                                        <div class="menu-filter-list" id="menu-ingredient-filter-list"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </th>
+                        <th scope="col">
+                            <div class="menu-header-cell">
+                                <span class="menu-header-label">Cuisine</span>
+                                <div class="menu-filter-control">
+                                    <button
+                                        aria-controls="menu-cuisine-filter-panel"
+                                        aria-expanded="false"
+                                        aria-haspopup="true"
+                                        class="menu-filter-button"
+                                        id="menu-cuisine-filter-toggle"
+                                        type="button"
+                                    >
+                                        Filter
+                                    </button>
+                                    <div
+                                        aria-label="Filter cuisines"
+                                        class="menu-filter-panel"
+                                        hidden
+                                        id="menu-cuisine-filter-panel"
+                                        role="group"
+                                    >
+                                        <div class="menu-filter-header">
+                                            <p class="menu-filter-title">Filter by cuisine</p>
+                                            <button
+                                                aria-disabled="true"
+                                                class="menu-filter-clear"
+                                                id="menu-cuisine-filter-clear"
+                                                type="button"
+                                            >
+                                                Clear
+                                            </button>
+                                        </div>
+                                        <div class="menu-filter-list" id="menu-cuisine-filter-list"></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </th>
                         <th scope="col">Story</th>
                     </tr>
                 </thead>

--- a/menuFilters.js
+++ b/menuFilters.js
@@ -1,0 +1,386 @@
+import {
+    AttributeBooleanValue,
+    AttributeName,
+    BrowserEventName,
+    KeyboardKey,
+    MenuElementId,
+    MenuFilterText
+} from "./constants.js";
+
+const MenuFilterType = Object.freeze({
+    INGREDIENT: "ingredient",
+    CUISINE: "cuisine"
+});
+
+const MenuFilterClassName = Object.freeze({
+    PANEL: "menu-filter-panel",
+    PANEL_OPEN: "is-open",
+    OPTION: "menu-filter-option",
+    OPTION_SELECTED: "is-selected",
+    OPTION_ICON: "menu-filter-option__icon",
+    OPTION_LABEL: "menu-filter-option__label"
+});
+
+const MenuFilterAttributeName = Object.freeze({
+    FILTER_VALUE: "data-filter-value",
+    FILTER_TYPE: "data-filter-type"
+});
+
+const MenuFilterIcon = Object.freeze({
+    CHECK: "✔"
+});
+
+const TextContent = Object.freeze({
+    EMPTY: ""
+});
+
+const ToggleLabelSuffix = Object.freeze({
+    COUNT_PREFIX: " (",
+    COUNT_SUFFIX: ")"
+});
+
+function isFunction(candidate) {
+    return typeof candidate === "function";
+}
+
+function isKeyboardEscape(keyValue) {
+    return keyValue === KeyboardKey.ESCAPE || keyValue === KeyboardKey.ESC;
+}
+
+export class MenuFilterController {
+    #documentReference;
+
+    #menuPresenter;
+
+    #controlElementIdMap;
+
+    #attributeNameMap;
+
+    #toggleElementsByType = new Map();
+
+    #panelElementsByType = new Map();
+
+    #listElementsByType = new Map();
+
+    #clearButtonByType = new Map();
+
+    #toggleBaseLabelByType = new Map();
+
+    #currentlyOpenFilterType = null;
+
+    #boundDocumentClickHandler = null;
+
+    #boundDocumentKeydownHandler = null;
+
+    constructor({
+        documentReference = document,
+        menuPresenter,
+        controlElementIdMap = MenuElementId,
+        attributeNameMap = AttributeName
+    } = {}) {
+        this.#documentReference = documentReference;
+        this.#menuPresenter = menuPresenter;
+        this.#controlElementIdMap = controlElementIdMap;
+        this.#attributeNameMap = attributeNameMap;
+    }
+
+    initialize() {
+        this.#cacheFilterElements();
+        this.#wireFilterInteractions();
+        this.#bindPresenterUpdates();
+    }
+
+    #cacheFilterElements() {
+        const filterDescriptors = [
+            Object.freeze({
+                filterType: MenuFilterType.INGREDIENT,
+                toggleId: this.#controlElementIdMap.INGREDIENT_FILTER_TOGGLE,
+                panelId: this.#controlElementIdMap.INGREDIENT_FILTER_PANEL,
+                listId: this.#controlElementIdMap.INGREDIENT_FILTER_LIST,
+                clearButtonId: this.#controlElementIdMap.INGREDIENT_FILTER_CLEAR,
+                ariaLabel: MenuFilterText.INGREDIENT_FILTER_ARIA_LABEL
+            }),
+            Object.freeze({
+                filterType: MenuFilterType.CUISINE,
+                toggleId: this.#controlElementIdMap.CUISINE_FILTER_TOGGLE,
+                panelId: this.#controlElementIdMap.CUISINE_FILTER_PANEL,
+                listId: this.#controlElementIdMap.CUISINE_FILTER_LIST,
+                clearButtonId: this.#controlElementIdMap.CUISINE_FILTER_CLEAR,
+                ariaLabel: MenuFilterText.CUISINE_FILTER_ARIA_LABEL
+            })
+        ];
+
+        for (const descriptor of filterDescriptors) {
+            const toggleElement = descriptor.toggleId
+                ? this.#documentReference.getElementById(descriptor.toggleId)
+                : null;
+            const panelElement = descriptor.panelId
+                ? this.#documentReference.getElementById(descriptor.panelId)
+                : null;
+            const listElement = descriptor.listId
+                ? this.#documentReference.getElementById(descriptor.listId)
+                : null;
+            const clearButtonElement = descriptor.clearButtonId
+                ? this.#documentReference.getElementById(descriptor.clearButtonId)
+                : null;
+
+            if (!toggleElement || !panelElement || !listElement) {
+                continue;
+            }
+
+            const baseLabel = toggleElement.textContent
+                ? toggleElement.textContent.trim()
+                : MenuFilterText.FILTER_LABEL;
+
+            toggleElement.setAttribute(
+                this.#attributeNameMap.ARIA_LABEL,
+                descriptor.ariaLabel
+            );
+
+            this.#toggleElementsByType.set(descriptor.filterType, toggleElement);
+            this.#panelElementsByType.set(descriptor.filterType, panelElement);
+            this.#listElementsByType.set(descriptor.filterType, listElement);
+            this.#toggleBaseLabelByType.set(descriptor.filterType, baseLabel);
+
+            if (clearButtonElement) {
+                this.#clearButtonByType.set(descriptor.filterType, clearButtonElement);
+            }
+        }
+    }
+
+    #wireFilterInteractions() {
+        for (const [filterType, toggleElement] of this.#toggleElementsByType.entries()) {
+            toggleElement.addEventListener(BrowserEventName.CLICK, (eventObject) => {
+                eventObject.preventDefault();
+                this.#toggleFilterMenu(filterType);
+            });
+        }
+
+        for (const [filterType, listElement] of this.#listElementsByType.entries()) {
+            listElement.addEventListener(BrowserEventName.CLICK, (eventObject) => {
+                const optionButton = eventObject.target instanceof Element
+                    ? eventObject.target.closest(`.${MenuFilterClassName.OPTION}`)
+                    : null;
+                if (!optionButton) {
+                    return;
+                }
+                const filterValue = optionButton.getAttribute(MenuFilterAttributeName.FILTER_VALUE);
+                const optionFilterType = optionButton.getAttribute(MenuFilterAttributeName.FILTER_TYPE);
+                if (!filterValue || optionFilterType !== filterType) {
+                    return;
+                }
+                this.#handleFilterToggleRequest(filterType, filterValue);
+            });
+        }
+
+        for (const [filterType, clearButton] of this.#clearButtonByType.entries()) {
+            clearButton.addEventListener(BrowserEventName.CLICK, (eventObject) => {
+                eventObject.preventDefault();
+                this.#clearFilters(filterType);
+            });
+        }
+
+        this.#boundDocumentClickHandler = (eventObject) => {
+            const eventTarget = eventObject.target instanceof Element ? eventObject.target : null;
+            if (!eventTarget) {
+                return;
+            }
+            if (!this.#isEventWithinFilterInterface(eventTarget)) {
+                this.#closeAllMenus();
+            }
+        };
+        this.#boundDocumentKeydownHandler = (eventObject) => {
+            if (!eventObject || !isKeyboardEscape(eventObject.key)) {
+                return;
+            }
+            const openFilterType = this.#currentlyOpenFilterType;
+            if (!openFilterType) {
+                return;
+            }
+            this.#closeAllMenus();
+            const toggleElement = this.#toggleElementsByType.get(openFilterType);
+            if (toggleElement && isFunction(toggleElement.focus)) {
+                toggleElement.focus();
+            }
+        };
+
+        this.#documentReference.addEventListener(BrowserEventName.CLICK, this.#boundDocumentClickHandler);
+        this.#documentReference.addEventListener(BrowserEventName.KEY_DOWN, this.#boundDocumentKeydownHandler);
+    }
+
+    #bindPresenterUpdates() {
+        if (!this.#menuPresenter || !isFunction(this.#menuPresenter.bindFilterOptionsChangeHandler)) {
+            return;
+        }
+        this.#menuPresenter.bindFilterOptionsChangeHandler((filterState) => {
+            this.#applyFilterStateUpdate(filterState);
+        });
+    }
+
+    #toggleFilterMenu(filterType) {
+        if (!filterType) {
+            return;
+        }
+        if (this.#currentlyOpenFilterType === filterType) {
+            this.#closeAllMenus();
+            return;
+        }
+        this.#openMenuForFilterType(filterType);
+    }
+
+    #openMenuForFilterType(filterType) {
+        this.#closeAllMenus();
+
+        const panelElement = this.#panelElementsByType.get(filterType);
+        const toggleElement = this.#toggleElementsByType.get(filterType);
+        if (!panelElement || !toggleElement) {
+            return;
+        }
+
+        panelElement.hidden = false;
+        panelElement.classList.add(MenuFilterClassName.PANEL_OPEN);
+        toggleElement.setAttribute(this.#attributeNameMap.ARIA_EXPANDED, AttributeBooleanValue.TRUE);
+        this.#currentlyOpenFilterType = filterType;
+    }
+
+    #closeAllMenus() {
+        for (const panelElement of this.#panelElementsByType.values()) {
+            panelElement.hidden = true;
+            panelElement.classList.remove(MenuFilterClassName.PANEL_OPEN);
+        }
+        for (const toggleElement of this.#toggleElementsByType.values()) {
+            toggleElement.setAttribute(this.#attributeNameMap.ARIA_EXPANDED, AttributeBooleanValue.FALSE);
+        }
+        this.#currentlyOpenFilterType = null;
+    }
+
+    #isEventWithinFilterInterface(targetElement) {
+        for (const toggleElement of this.#toggleElementsByType.values()) {
+            if (toggleElement && toggleElement.contains(targetElement)) {
+                return true;
+            }
+        }
+        for (const panelElement of this.#panelElementsByType.values()) {
+            if (panelElement && panelElement.contains(targetElement)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    #handleFilterToggleRequest(filterType, filterValue) {
+        if (!this.#menuPresenter || !filterValue) {
+            return;
+        }
+        if (filterType === MenuFilterType.INGREDIENT && isFunction(this.#menuPresenter.toggleIngredientFilter)) {
+            this.#menuPresenter.toggleIngredientFilter(filterValue);
+        }
+        if (filterType === MenuFilterType.CUISINE && isFunction(this.#menuPresenter.toggleCuisineFilter)) {
+            this.#menuPresenter.toggleCuisineFilter(filterValue);
+        }
+    }
+
+    #clearFilters(filterType) {
+        if (!this.#menuPresenter) {
+            return;
+        }
+        if (filterType === MenuFilterType.INGREDIENT && isFunction(this.#menuPresenter.clearIngredientFilters)) {
+            this.#menuPresenter.clearIngredientFilters();
+        }
+        if (filterType === MenuFilterType.CUISINE && isFunction(this.#menuPresenter.clearCuisineFilters)) {
+            this.#menuPresenter.clearCuisineFilters();
+        }
+    }
+
+    #applyFilterStateUpdate(filterState = {}) {
+        const cuisineOptions = Array.isArray(filterState.cuisines) ? filterState.cuisines : [];
+        const ingredientOptions = Array.isArray(filterState.ingredients) ? filterState.ingredients : [];
+        const selectedCuisineValues = new Set(filterState.selectedCuisineValues || []);
+        const selectedIngredientValues = new Set(filterState.selectedIngredientValues || []);
+
+        this.#renderFilterOptions(MenuFilterType.CUISINE, cuisineOptions, selectedCuisineValues);
+        this.#renderFilterOptions(MenuFilterType.INGREDIENT, ingredientOptions, selectedIngredientValues);
+
+        this.#updateToggleSummary(MenuFilterType.CUISINE, selectedCuisineValues.size);
+        this.#updateToggleSummary(MenuFilterType.INGREDIENT, selectedIngredientValues.size);
+
+        this.#updateClearButtonState(MenuFilterType.CUISINE, selectedCuisineValues.size > 0);
+        this.#updateClearButtonState(MenuFilterType.INGREDIENT, selectedIngredientValues.size > 0);
+    }
+
+    #renderFilterOptions(filterType, optionDescriptors, selectedValuesSet) {
+        const listElement = this.#listElementsByType.get(filterType);
+        if (!listElement) {
+            return;
+        }
+
+        listElement.textContent = TextContent.EMPTY;
+
+        for (const optionDescriptor of optionDescriptors) {
+            if (!optionDescriptor || !optionDescriptor.value) {
+                continue;
+            }
+
+            const optionButton = this.#documentReference.createElement("button");
+            optionButton.type = "button";
+            optionButton.className = MenuFilterClassName.OPTION;
+            optionButton.setAttribute(MenuFilterAttributeName.FILTER_VALUE, optionDescriptor.value);
+            optionButton.setAttribute(MenuFilterAttributeName.FILTER_TYPE, filterType);
+
+            const isSelected = selectedValuesSet.has(optionDescriptor.value);
+            optionButton.setAttribute(
+                this.#attributeNameMap.ARIA_PRESSED,
+                isSelected ? AttributeBooleanValue.TRUE : AttributeBooleanValue.FALSE
+            );
+            if (isSelected) {
+                optionButton.classList.add(MenuFilterClassName.OPTION_SELECTED);
+            }
+
+            const iconSpan = this.#documentReference.createElement("span");
+            iconSpan.className = MenuFilterClassName.OPTION_ICON;
+            iconSpan.textContent = isSelected ? MenuFilterIcon.CHECK : TextContent.EMPTY;
+
+            const labelSpan = this.#documentReference.createElement("span");
+            labelSpan.className = MenuFilterClassName.OPTION_LABEL;
+            labelSpan.textContent = optionDescriptor.label || optionDescriptor.value;
+
+            optionButton.appendChild(iconSpan);
+            optionButton.appendChild(labelSpan);
+
+            listElement.appendChild(optionButton);
+        }
+    }
+
+    #updateToggleSummary(filterType, selectedCount) {
+        const toggleElement = this.#toggleElementsByType.get(filterType);
+        if (!toggleElement) {
+            return;
+        }
+        const baseLabel = this.#toggleBaseLabelByType.get(filterType) || MenuFilterText.FILTER_LABEL;
+        const ariaLabel = filterType === MenuFilterType.CUISINE
+            ? MenuFilterText.CUISINE_FILTER_ARIA_LABEL
+            : MenuFilterText.INGREDIENT_FILTER_ARIA_LABEL;
+
+        let renderedLabel = baseLabel;
+        let renderedAriaLabel = ariaLabel;
+        if (selectedCount > 0) {
+            renderedLabel = `${baseLabel}${ToggleLabelSuffix.COUNT_PREFIX}${selectedCount}${ToggleLabelSuffix.COUNT_SUFFIX}`;
+            renderedAriaLabel = `${ariaLabel}${ToggleLabelSuffix.COUNT_PREFIX}${selectedCount} selected${ToggleLabelSuffix.COUNT_SUFFIX}`;
+        }
+
+        toggleElement.textContent = renderedLabel;
+        toggleElement.setAttribute(this.#attributeNameMap.ARIA_LABEL, renderedAriaLabel);
+    }
+
+    #updateClearButtonState(filterType, hasActiveSelections) {
+        const clearButton = this.#clearButtonByType.get(filterType);
+        if (!clearButton) {
+            return;
+        }
+        clearButton.disabled = !hasActiveSelections;
+        clearButton.setAttribute(
+            this.#attributeNameMap.ARIA_DISABLED,
+            hasActiveSelections ? AttributeBooleanValue.FALSE : AttributeBooleanValue.TRUE
+        );
+    }
+}

--- a/tests/integration/menuFilters.integration.test.js
+++ b/tests/integration/menuFilters.integration.test.js
@@ -11,15 +11,12 @@ const HtmlTagName = Object.freeze({
   TH: "th",
   DIV: "div",
   BUTTON: "button",
-  SPAN: "span",
   P: "p"
 });
 
 const CssClassName = Object.freeze({
   HEADER_CELL: "menu-header-cell",
-  HEADER_LABEL: "menu-header-label",
-  FILTER_CONTROL: "menu-filter-control",
-  FILTER_BUTTON: "menu-filter-button",
+  HEADER_TOGGLE: "menu-header-toggle",
   FILTER_PANEL: "menu-filter-panel",
   FILTER_HEADER: "menu-filter-header",
   FILTER_TITLE: "menu-filter-title",
@@ -121,65 +118,59 @@ function buildMenuTableMarkup() {
           <${HtmlTagName.TH}>Dish</${HtmlTagName.TH}>
           <${HtmlTagName.TH}>
             <${HtmlTagName.DIV} class="${CssClassName.HEADER_CELL}">
-              <${HtmlTagName.SPAN} class="${CssClassName.HEADER_LABEL}">Ingredients</${HtmlTagName.SPAN}>
-              <${HtmlTagName.DIV} class="${CssClassName.FILTER_CONTROL}">
-                <${HtmlTagName.BUTTON}
-                  id="${MenuElementId.INGREDIENT_FILTER_TOGGLE}"
-                  class="${CssClassName.FILTER_BUTTON}"
-                  aria-controls="${MenuElementId.INGREDIENT_FILTER_PANEL}"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  type="button"
-                >Filter</${HtmlTagName.BUTTON}>
-                <${HtmlTagName.DIV}
-                  id="${MenuElementId.INGREDIENT_FILTER_PANEL}"
-                  class="${CssClassName.FILTER_PANEL}"
-                  hidden
-                  role="group"
-                >
-                  <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
-                    <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by ingredient</${HtmlTagName.P}>
-                    <${HtmlTagName.BUTTON}
-                      id="${MenuElementId.INGREDIENT_FILTER_CLEAR}"
-                      class="${CssClassName.FILTER_CLEAR}"
-                      aria-disabled="true"
-                      type="button"
-                    >Clear</${HtmlTagName.BUTTON}>
-                  </${HtmlTagName.DIV}>
-                  <${HtmlTagName.DIV} id="${MenuElementId.INGREDIENT_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
+              <${HtmlTagName.BUTTON}
+                id="${MenuElementId.INGREDIENT_FILTER_TOGGLE}"
+                class="${CssClassName.HEADER_TOGGLE}"
+                aria-controls="${MenuElementId.INGREDIENT_FILTER_PANEL}"
+                aria-haspopup="true"
+                aria-expanded="false"
+                type="button"
+              >Ingredients</${HtmlTagName.BUTTON}>
+              <${HtmlTagName.DIV}
+                id="${MenuElementId.INGREDIENT_FILTER_PANEL}"
+                class="${CssClassName.FILTER_PANEL}"
+                hidden
+                role="group"
+              >
+                <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
+                  <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by ingredient</${HtmlTagName.P}>
+                  <${HtmlTagName.BUTTON}
+                    id="${MenuElementId.INGREDIENT_FILTER_CLEAR}"
+                    class="${CssClassName.FILTER_CLEAR}"
+                    aria-disabled="true"
+                    type="button"
+                  >Clear</${HtmlTagName.BUTTON}>
                 </${HtmlTagName.DIV}>
+                <${HtmlTagName.DIV} id="${MenuElementId.INGREDIENT_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
               </${HtmlTagName.DIV}>
             </${HtmlTagName.DIV}>
           </${HtmlTagName.TH}>
           <${HtmlTagName.TH}>
             <${HtmlTagName.DIV} class="${CssClassName.HEADER_CELL}">
-              <${HtmlTagName.SPAN} class="${CssClassName.HEADER_LABEL}">Cuisine</${HtmlTagName.SPAN}>
-              <${HtmlTagName.DIV} class="${CssClassName.FILTER_CONTROL}">
-                <${HtmlTagName.BUTTON}
-                  id="${MenuElementId.CUISINE_FILTER_TOGGLE}"
-                  class="${CssClassName.FILTER_BUTTON}"
-                  aria-controls="${MenuElementId.CUISINE_FILTER_PANEL}"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  type="button"
-                >Filter</${HtmlTagName.BUTTON}>
-                <${HtmlTagName.DIV}
-                  id="${MenuElementId.CUISINE_FILTER_PANEL}"
-                  class="${CssClassName.FILTER_PANEL}"
-                  hidden
-                  role="group"
-                >
-                  <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
-                    <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by cuisine</${HtmlTagName.P}>
-                    <${HtmlTagName.BUTTON}
-                      id="${MenuElementId.CUISINE_FILTER_CLEAR}"
-                      class="${CssClassName.FILTER_CLEAR}"
-                      aria-disabled="true"
-                      type="button"
-                    >Clear</${HtmlTagName.BUTTON}>
-                  </${HtmlTagName.DIV}>
-                  <${HtmlTagName.DIV} id="${MenuElementId.CUISINE_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
+              <${HtmlTagName.BUTTON}
+                id="${MenuElementId.CUISINE_FILTER_TOGGLE}"
+                class="${CssClassName.HEADER_TOGGLE}"
+                aria-controls="${MenuElementId.CUISINE_FILTER_PANEL}"
+                aria-haspopup="true"
+                aria-expanded="false"
+                type="button"
+              >Cuisine</${HtmlTagName.BUTTON}>
+              <${HtmlTagName.DIV}
+                id="${MenuElementId.CUISINE_FILTER_PANEL}"
+                class="${CssClassName.FILTER_PANEL}"
+                hidden
+                role="group"
+              >
+                <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
+                  <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by cuisine</${HtmlTagName.P}>
+                  <${HtmlTagName.BUTTON}
+                    id="${MenuElementId.CUISINE_FILTER_CLEAR}"
+                    class="${CssClassName.FILTER_CLEAR}"
+                    aria-disabled="true"
+                    type="button"
+                  >Clear</${HtmlTagName.BUTTON}>
                 </${HtmlTagName.DIV}>
+                <${HtmlTagName.DIV} id="${MenuElementId.CUISINE_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
               </${HtmlTagName.DIV}>
             </${HtmlTagName.DIV}>
           </${HtmlTagName.TH}>

--- a/tests/integration/menuFilters.integration.test.js
+++ b/tests/integration/menuFilters.integration.test.js
@@ -1,0 +1,292 @@
+import { MenuView } from "../../menu.js";
+import { MenuFilterController } from "../../menuFilters.js";
+import { MenuElementId } from "../../constants.js";
+import { NormalizationEngine } from "../../utils.js";
+
+const HtmlTagName = Object.freeze({
+  TABLE: "table",
+  THEAD: "thead",
+  TBODY: "tbody",
+  TR: "tr",
+  TH: "th",
+  DIV: "div",
+  BUTTON: "button",
+  SPAN: "span",
+  P: "p"
+});
+
+const CssClassName = Object.freeze({
+  HEADER_CELL: "menu-header-cell",
+  HEADER_LABEL: "menu-header-label",
+  FILTER_CONTROL: "menu-filter-control",
+  FILTER_BUTTON: "menu-filter-button",
+  FILTER_PANEL: "menu-filter-panel",
+  FILTER_HEADER: "menu-filter-header",
+  FILTER_TITLE: "menu-filter-title",
+  FILTER_CLEAR: "menu-filter-clear",
+  FILTER_LIST: "menu-filter-list",
+  FILTER_OPTION: "menu-filter-option",
+  EMPTY_ROW: "menu-row--empty"
+});
+
+const FilterDataAttribute = Object.freeze({
+  TYPE: "data-filter-type",
+  VALUE: "data-filter-value"
+});
+
+const FilterType = Object.freeze({
+  CUISINE: "cuisine",
+  INGREDIENT: "ingredient"
+});
+
+const MenuEmptyMessage = "No dishes match the selected filters.";
+
+const SampleDishes = Object.freeze([
+  Object.freeze({
+    id: "dish-nori-ramen",
+    name: "Nori Ramen Bowl",
+    emoji: "🍜",
+    cuisine: "Japanese",
+    ingredients: ["Nori", "Soy Sauce", "Egg"],
+    narrative: "Warm ramen with seaweed."
+  }),
+  Object.freeze({
+    id: "dish-sushi",
+    name: "Rainbow Sushi",
+    emoji: "🍣",
+    cuisine: "Japanese",
+    ingredients: ["Rice", "Salmon", "Avocado"],
+    narrative: "Colorful sushi roll."
+  }),
+  Object.freeze({
+    id: "dish-pasta",
+    name: "Garden Pesto Pasta",
+    emoji: "🍝",
+    cuisine: "Italian",
+    ingredients: ["Basil", "Tomato", "Parmesan"],
+    narrative: "Herby pasta dinner."
+  })
+]);
+
+const FilterInteractionScenario = Object.freeze({
+  APPLY_BOTH: "filters dishes when cuisine and ingredient options are selected",
+  NO_MATCHES: "renders an empty state when filters have no matches",
+  CLEAR_FILTERS: "clearing filters restores every dish"
+});
+
+const FilterInteractionScenarios = Object.freeze([
+  Object.freeze({
+    description: FilterInteractionScenario.APPLY_BOTH,
+    arrange: ({ selectCuisine, selectIngredient }) => {
+      selectCuisine("japanese");
+      selectIngredient("soy sauce");
+    },
+    expectedRowCount: 1,
+    expectedDishNames: ["Nori Ramen Bowl"],
+    expectEmptyState: false
+  }),
+  Object.freeze({
+    description: FilterInteractionScenario.NO_MATCHES,
+    arrange: ({ selectCuisine, selectIngredient }) => {
+      selectCuisine("japanese");
+      selectIngredient("basil");
+    },
+    expectedRowCount: 1,
+    expectedDishNames: [],
+    expectEmptyState: true
+  }),
+  Object.freeze({
+    description: FilterInteractionScenario.CLEAR_FILTERS,
+    arrange: ({ selectCuisine, selectIngredient, clearCuisine, clearIngredient }) => {
+      selectCuisine("japanese");
+      selectIngredient("soy sauce");
+      clearCuisine();
+      clearIngredient();
+    },
+    expectedRowCount: SampleDishes.length,
+    expectedDishNames: SampleDishes.map((dish) => dish.name),
+    expectEmptyState: false
+  })
+]);
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function buildMenuTableMarkup() {
+  return `
+    <${HtmlTagName.TABLE}>
+      <${HtmlTagName.THEAD}>
+        <${HtmlTagName.TR}>
+          <${HtmlTagName.TH}>Dish</${HtmlTagName.TH}>
+          <${HtmlTagName.TH}>
+            <${HtmlTagName.DIV} class="${CssClassName.HEADER_CELL}">
+              <${HtmlTagName.SPAN} class="${CssClassName.HEADER_LABEL}">Ingredients</${HtmlTagName.SPAN}>
+              <${HtmlTagName.DIV} class="${CssClassName.FILTER_CONTROL}">
+                <${HtmlTagName.BUTTON}
+                  id="${MenuElementId.INGREDIENT_FILTER_TOGGLE}"
+                  class="${CssClassName.FILTER_BUTTON}"
+                  aria-controls="${MenuElementId.INGREDIENT_FILTER_PANEL}"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  type="button"
+                >Filter</${HtmlTagName.BUTTON}>
+                <${HtmlTagName.DIV}
+                  id="${MenuElementId.INGREDIENT_FILTER_PANEL}"
+                  class="${CssClassName.FILTER_PANEL}"
+                  hidden
+                  role="group"
+                >
+                  <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
+                    <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by ingredient</${HtmlTagName.P}>
+                    <${HtmlTagName.BUTTON}
+                      id="${MenuElementId.INGREDIENT_FILTER_CLEAR}"
+                      class="${CssClassName.FILTER_CLEAR}"
+                      aria-disabled="true"
+                      type="button"
+                    >Clear</${HtmlTagName.BUTTON}>
+                  </${HtmlTagName.DIV}>
+                  <${HtmlTagName.DIV} id="${MenuElementId.INGREDIENT_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
+                </${HtmlTagName.DIV}>
+              </${HtmlTagName.DIV}>
+            </${HtmlTagName.DIV}>
+          </${HtmlTagName.TH}>
+          <${HtmlTagName.TH}>
+            <${HtmlTagName.DIV} class="${CssClassName.HEADER_CELL}">
+              <${HtmlTagName.SPAN} class="${CssClassName.HEADER_LABEL}">Cuisine</${HtmlTagName.SPAN}>
+              <${HtmlTagName.DIV} class="${CssClassName.FILTER_CONTROL}">
+                <${HtmlTagName.BUTTON}
+                  id="${MenuElementId.CUISINE_FILTER_TOGGLE}"
+                  class="${CssClassName.FILTER_BUTTON}"
+                  aria-controls="${MenuElementId.CUISINE_FILTER_PANEL}"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  type="button"
+                >Filter</${HtmlTagName.BUTTON}>
+                <${HtmlTagName.DIV}
+                  id="${MenuElementId.CUISINE_FILTER_PANEL}"
+                  class="${CssClassName.FILTER_PANEL}"
+                  hidden
+                  role="group"
+                >
+                  <${HtmlTagName.DIV} class="${CssClassName.FILTER_HEADER}">
+                    <${HtmlTagName.P} class="${CssClassName.FILTER_TITLE}">Filter by cuisine</${HtmlTagName.P}>
+                    <${HtmlTagName.BUTTON}
+                      id="${MenuElementId.CUISINE_FILTER_CLEAR}"
+                      class="${CssClassName.FILTER_CLEAR}"
+                      aria-disabled="true"
+                      type="button"
+                    >Clear</${HtmlTagName.BUTTON}>
+                  </${HtmlTagName.DIV}>
+                  <${HtmlTagName.DIV} id="${MenuElementId.CUISINE_FILTER_LIST}" class="${CssClassName.FILTER_LIST}"></${HtmlTagName.DIV}>
+                </${HtmlTagName.DIV}>
+              </${HtmlTagName.DIV}>
+            </${HtmlTagName.DIV}>
+          </${HtmlTagName.TH}>
+          <${HtmlTagName.TH}>Story</${HtmlTagName.TH}>
+        </${HtmlTagName.TR}>
+      </${HtmlTagName.THEAD}>
+      <${HtmlTagName.TBODY} id="${MenuElementId.TABLE_BODY}"></${HtmlTagName.TBODY}>
+    </${HtmlTagName.TABLE}>
+  `;
+}
+
+function createInteractionHelpers() {
+  const selectFilterOption = (filterType, filterValue) => {
+    const toggleId =
+      filterType === FilterType.CUISINE
+        ? MenuElementId.CUISINE_FILTER_TOGGLE
+        : MenuElementId.INGREDIENT_FILTER_TOGGLE;
+    const toggleElement = document.getElementById(toggleId);
+    toggleElement.click();
+
+    const optionSelector = `.${CssClassName.FILTER_OPTION}[${FilterDataAttribute.TYPE}="${filterType}"][${FilterDataAttribute.VALUE}="${filterValue}"]`;
+    const optionElement = document.querySelector(optionSelector);
+    if (!optionElement) {
+      throw new Error(`Option for ${filterType} with value ${filterValue} not found`);
+    }
+    optionElement.click();
+  };
+
+  const clearFilters = (filterType) => {
+    const clearButtonId =
+      filterType === FilterType.CUISINE
+        ? MenuElementId.CUISINE_FILTER_CLEAR
+        : MenuElementId.INGREDIENT_FILTER_CLEAR;
+    const clearButton = document.getElementById(clearButtonId);
+    if (clearButton.disabled) {
+      throw new Error(`Clear button for ${filterType} should be enabled before clearing`);
+    }
+    clearButton.click();
+  };
+
+  return {
+    selectCuisine: (value) => selectFilterOption(FilterType.CUISINE, value),
+    selectIngredient: (value) => selectFilterOption(FilterType.INGREDIENT, value),
+    clearCuisine: () => clearFilters(FilterType.CUISINE),
+    clearIngredient: () => clearFilters(FilterType.INGREDIENT)
+  };
+}
+
+describe("Menu filters", () => {
+  test.each(FilterInteractionScenarios)("%s", ({
+    arrange,
+    expectedRowCount,
+    expectedDishNames,
+    expectEmptyState
+  }) => {
+    document.body.innerHTML = buildMenuTableMarkup();
+
+    const menuTableBodyElement = document.getElementById(MenuElementId.TABLE_BODY);
+
+    const menuView = new MenuView({
+      documentReference: document,
+      menuTableBodyElement
+    });
+
+    const menuFilterController = new MenuFilterController({
+      documentReference: document,
+      menuPresenter: menuView
+    });
+
+    menuFilterController.initialize();
+
+    const normalizationEngine = new NormalizationEngine([]);
+
+    menuView.updateDataDependencies({
+      dishesCatalog: SampleDishes,
+      normalizationEngine,
+      ingredientEmojiByName: new Map(),
+      cuisineToFlagMap: new Map(),
+      allergensCatalog: []
+    });
+    menuView.renderMenu();
+
+    const helpers = createInteractionHelpers();
+    arrange(helpers);
+
+    const renderedRows = Array.from(menuTableBodyElement.querySelectorAll(HtmlTagName.TR));
+    expect(renderedRows).toHaveLength(expectedRowCount);
+
+    const emptyRows = renderedRows.filter((rowElement) =>
+      rowElement.classList.contains(CssClassName.EMPTY_ROW)
+    );
+
+    if (expectEmptyState) {
+      expect(emptyRows).toHaveLength(1);
+      expect(emptyRows[0].textContent).toContain(MenuEmptyMessage);
+    } else {
+      expect(emptyRows).toHaveLength(0);
+    }
+
+    const renderedDishRows = renderedRows.filter(
+      (rowElement) => !rowElement.classList.contains(CssClassName.EMPTY_ROW)
+    );
+
+    for (const expectedName of expectedDishNames) {
+      expect(
+        renderedDishRows.some((rowElement) => rowElement.textContent.includes(expectedName))
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add accessible menu filter controls and styles to the menu header
- extend MenuView with filter state tracking and expose filter hooks
- introduce a MenuFilterController to wire DOM interactions and render options
- add integration coverage for cuisine and ingredient filtering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb152a6cfc83279bbfd585f236b121