### PR TITLE
Set ingredient chips to use default cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -878,7 +878,7 @@
         .tag { background: #d1f7ff; border: 2px solid #000; border-radius: 14px; padding: 6px 10px; font-weight: 800 }
 
         .ingredients { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px }
-        .ingredient { display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; border: 2px solid #000; border-radius: 999px; background: #f4f4f4; font-weight: 700 }
+        .ingredient { display: inline-flex; align-items: center; gap: 6px; padding: 8px 12px; border: 2px solid #000; border-radius: 999px; background: #f4f4f4; font-weight: 700; cursor: default; }
         .ingredient.bad { background: #ffd0d6 }
         .ingredient .emoji-large { line-height: 1; }
 


### PR DESCRIPTION
## Summary
- ensure ingredient chips use the default cursor on hover

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb80590bc883278982e089cfde31a5