### PR TITLE
Add onboarding goal copy to quick game card

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Allergy Wheel
 
-An interactive allergy wheel game rendered in the browser. The project now includes automated tests powered by Jest to validate utility helpers, state transitions, and canvas-based integration scenarios.
+An interactive allergy wheel game rendered in the browser. The project now includes automated tests powered by Jest to validate utility helpers, state transitions, and canvas-based integration scenarios. When players land on the quick game screen they are invited to pick any troublesome allergens and see a goal reminder to spin the allergy wheel to win 10 hearts.
 
 ## Prerequisites
 

--- a/index.html
+++ b/index.html
@@ -964,6 +964,7 @@
         <div class="card__body">
             <h2 class="title" id="allergy-title">Pick your allergens</h2>
             <p class="muted">Choose anything that might cause trouble. You can change this later.</p>
+            <p class="muted">Spin the allergy wheel to win 10 hearts!</p>
             <div class="grid allergen-grid" id="allergy-list">
                 <button
                     aria-disabled="true"

--- a/tests/integration/onboarding.integration.test.js
+++ b/tests/integration/onboarding.integration.test.js
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ControlElementId } from "../../constants.js";
+
+const CurrentModuleFilePath = fileURLToPath(import.meta.url);
+const IntegrationTestDirectoryPath = dirname(CurrentModuleFilePath);
+const ProjectRootDirectoryPath = join(IntegrationTestDirectoryPath, "..", "..");
+const IndexDocumentFileName = "index.html";
+const IndexDocumentFilePath = join(ProjectRootDirectoryPath, IndexDocumentFileName);
+
+const OnboardingCopyText = Object.freeze({
+  INSTRUCTION: "Choose anything that might cause trouble. You can change this later.",
+  GOAL: "Spin the allergy wheel to win 10 hearts!"
+});
+
+const OnboardingParagraphDescription = Object.freeze({
+  INSTRUCTION: "guides players to select potential allergens",
+  GOAL: "explains the heart-winning objective"
+});
+
+const OnboardingElementSelector = Object.freeze({
+  CARD_BODY: "#screen-allergy .card__body",
+  MUTED_PARAGRAPH: "p.muted"
+});
+
+const OnboardingParagraphExpectationTable = Object.freeze([
+  Object.freeze({
+    description: OnboardingParagraphDescription.INSTRUCTION,
+    expectedText: OnboardingCopyText.INSTRUCTION
+  }),
+  Object.freeze({
+    description: OnboardingParagraphDescription.GOAL,
+    expectedText: OnboardingCopyText.GOAL
+  })
+]);
+
+describe("Allergy onboarding copy", () => {
+  let parsedHtmlDocument;
+  let quickGameCardBodyElement;
+  let mutedParagraphTextList;
+
+  beforeAll(() => {
+    const indexHtmlSource = readFileSync(IndexDocumentFilePath, { encoding: "utf-8" });
+    const DomParserConstructor = globalThis.DOMParser;
+    expect(DomParserConstructor).toBeDefined();
+    const htmlParser = new DomParserConstructor();
+    parsedHtmlDocument = htmlParser.parseFromString(indexHtmlSource, "text/html");
+    quickGameCardBodyElement = parsedHtmlDocument.querySelector(OnboardingElementSelector.CARD_BODY);
+    mutedParagraphTextList = quickGameCardBodyElement
+      ? Array.from(
+          quickGameCardBodyElement.querySelectorAll(OnboardingElementSelector.MUTED_PARAGRAPH),
+          (paragraphElement) => paragraphElement.textContent.trim()
+        )
+      : [];
+  });
+
+  test("exposes the allergen selection title element", () => {
+    const allergyTitleElement = parsedHtmlDocument.getElementById(ControlElementId.ALLERGY_TITLE);
+    expect(allergyTitleElement).not.toBeNull();
+  });
+
+  test.each(OnboardingParagraphExpectationTable)(
+    "renders onboarding paragraph that $description",
+    ({ expectedText }) => {
+      expect(quickGameCardBodyElement).not.toBeNull();
+      expect(mutedParagraphTextList).toContain(expectedText);
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a goal reminder beneath the allergen selection instructions on the quick game card
- document the new goal copy in the project README
- cover the onboarding text with a jsdom-based integration test to ensure both instructions render

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb862b21b083279780a4e4d98ff74e