### PR TITLE
Ensure reveal banner result text uses default cursor

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,6 +883,7 @@
         .ingredient .emoji-large { line-height: 1; }
 
         .banner { display: flex; align-items: center; gap: 12px; margin-top: 12px; border: 3px dashed #000; border-radius: 16px; padding: 10px }
+        .banner #result-text { cursor: default; }
         .ok { background: #d9fbe9 }
         .bad { background: #ffe2e6 }
 


### PR DESCRIPTION
## Summary
- add a dedicated CSS rule so the reveal banner result text keeps the default cursor

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc3d10e9688327b6d2f36ac5ef33a6