### PR TITLE
Display avatar labels in selector

### DIFF
--- a/avatarRenderer.js
+++ b/avatarRenderer.js
@@ -120,6 +120,13 @@ function createMenuOptionButton({
     optionImageElement.alt = `${avatarDescriptor.displayName}${avatarMenuText.OPTION_ALT_SUFFIX}`;
     optionButtonElement.appendChild(optionImageElement);
 
+    const optionLabelElement = documentReference.createElement(HtmlTagName.SPAN);
+    if (avatarClassNameMap.LABEL) {
+        optionLabelElement.classList.add(avatarClassNameMap.LABEL);
+    }
+    optionLabelElement.textContent = avatarDescriptor.displayName;
+    optionButtonElement.appendChild(optionLabelElement);
+
     return optionButtonElement;
 }
 

--- a/index.html
+++ b/index.html
@@ -126,8 +126,24 @@
         .avatar-image { width: 100%; height: 100%; border-radius: 50%; display: block; }
 
         .avatar-option {
-            width: 58px;
-            height: 58px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: flex-start;
+            gap: 6px;
+            width: 96px;
+            height: auto;
+            padding: 10px;
+            border-radius: 18px;
+        }
+
+        .avatar-option .avatar-image {
+            width: 48px;
+            height: 48px;
+        }
+
+        .avatar-option .avatar-label {
+            text-align: center;
         }
 
         #avatar-menu {

--- a/tests/integration/avatarSelection.test.js
+++ b/tests/integration/avatarSelection.test.js
@@ -126,6 +126,16 @@ function expectAvatarMenuMatchesCatalog(avatarMenuElement) {
     expect(optionImageElement.getAttribute(HtmlAttributeName.ALT)).toBe(
       `${expectedDescriptor.displayName}${AvatarMenuText.OPTION_ALT_SUFFIX}`
     );
+
+    const optionLabelElement = optionElement.querySelector(
+      `.${AvatarClassName.LABEL}`
+    );
+    expect(optionLabelElement).not.toBeNull();
+    if (optionLabelElement) {
+      expect(optionLabelElement.textContent).toBe(
+        expectedDescriptor.displayName
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- append avatar display names to each avatar menu option for clearer identification
- adjust avatar menu styling to support stacked image and text content without breaking layout
- extend avatar selector integration test to confirm menu options render matching labels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccea0cbf188327b4939b7ca7b9d866