### PR TITLE
Hide header avatar label and update tests

### DIFF
--- a/avatarRenderer.js
+++ b/avatarRenderer.js
@@ -45,10 +45,18 @@ function createToggleImageElement({
     return imageElement;
 }
 
-function createToggleLabelElement({ documentReference, avatarClassNameMap, activeDescriptor }) {
+function createToggleLabelElement({
+    documentReference,
+    avatarClassNameMap,
+    activeDescriptor,
+    globalClassName
+}) {
     const labelElement = documentReference.createElement(HtmlTagName.SPAN);
     if (avatarClassNameMap.LABEL) {
-        labelElement.className = avatarClassNameMap.LABEL;
+        labelElement.classList.add(avatarClassNameMap.LABEL);
+    }
+    if (globalClassName && globalClassName.VISUALLY_HIDDEN) {
+        labelElement.classList.add(globalClassName.VISUALLY_HIDDEN);
     }
     labelElement.textContent = activeDescriptor ? activeDescriptor.displayName : "";
     return labelElement;
@@ -86,7 +94,8 @@ function populateToggleButton({
     const labelElement = createToggleLabelElement({
         documentReference,
         avatarClassNameMap,
-        activeDescriptor
+        activeDescriptor,
+        globalClassName
     });
 
     toggleButtonElement.appendChild(hiddenPromptElement);

--- a/index.html
+++ b/index.html
@@ -99,11 +99,11 @@
 
         #avatar-toggle {
             display: inline-flex;
-            flex-direction: row;
             align-items: center;
-            gap: 10px;
-            padding: 6px 16px;
-            border-radius: 999px;
+            justify-content: center;
+            gap: 0;
+            padding: 6px;
+            border-radius: 50%;
         }
 
         #avatar-toggle .avatar-image {

--- a/tests/integration/avatarSelection.integration.test.js
+++ b/tests/integration/avatarSelection.integration.test.js
@@ -10,7 +10,8 @@ import {
   AvatarId,
   AvatarCatalog,
   AvatarClassName,
-  AvatarMenuText
+  AvatarMenuText,
+  GlobalClassName
 } from "../../constants.js";
 
 const EmptyStringValue = "";
@@ -124,6 +125,21 @@ function expectAvatarMenuMatchesCatalog(avatarMenuElement) {
     expect(optionImageElement.getAttribute(HtmlAttributeName.ALT)).toBe(
       `${expectedDescriptor.displayName}${AvatarMenuText.OPTION_ALT_SUFFIX}`
     );
+
+    const optionLabelElement = optionElement.querySelector(
+      `.${AvatarClassName.LABEL}`
+    );
+    expect(optionLabelElement).not.toBeNull();
+    if (optionLabelElement) {
+      expect(optionLabelElement.textContent).toBe(
+        expectedDescriptor.displayName
+      );
+      expect(
+        optionLabelElement.classList.contains(
+          GlobalClassName.VISUALLY_HIDDEN
+        )
+      ).toBe(false);
+    }
   }
 }
 
@@ -142,6 +158,9 @@ function expectToggleMatchesDescriptor({
   }
   if (labelElement) {
     expect(labelElement.textContent).toBe(descriptor.displayName);
+    expect(
+      labelElement.classList.contains(GlobalClassName.VISUALLY_HIDDEN)
+    ).toBe(true);
   }
 }
 
@@ -392,6 +411,11 @@ describe("Avatar selection integration", () => {
       expect(headerAvatarLabelElement.textContent).toBe(
         expectedAvatarDescriptor.displayName
       );
+      expect(
+        headerAvatarLabelElement.classList.contains(
+          GlobalClassName.VISUALLY_HIDDEN
+        )
+      ).toBe(true);
 
       const renderedAvatarImageElement = faceSvgElement.querySelector(SvgSelector.IMAGE);
       expect(renderedAvatarImageElement).not.toBeNull();

--- a/tests/integration/avatarSelection.test.js
+++ b/tests/integration/avatarSelection.test.js
@@ -10,7 +10,8 @@ import {
   AvatarId,
   AvatarCatalog,
   AvatarClassName,
-  AvatarMenuText
+  AvatarMenuText,
+  GlobalClassName
 } from "../../constants.js";
 
 const EmptyStringValue = "";
@@ -135,6 +136,11 @@ function expectAvatarMenuMatchesCatalog(avatarMenuElement) {
       expect(optionLabelElement.textContent).toBe(
         expectedDescriptor.displayName
       );
+      expect(
+        optionLabelElement.classList.contains(
+          GlobalClassName.VISUALLY_HIDDEN
+        )
+      ).toBe(false);
     }
   }
 }
@@ -154,6 +160,9 @@ function expectToggleMatchesDescriptor({
   }
   if (labelElement) {
     expect(labelElement.textContent).toBe(descriptor.displayName);
+    expect(
+      labelElement.classList.contains(GlobalClassName.VISUALLY_HIDDEN)
+    ).toBe(true);
   }
 }
 
@@ -416,6 +425,11 @@ describe("Avatar selection persistence", () => {
     expect(headerAvatarLabelElement.textContent).toBe(
       expectedAvatarDescriptor.displayName
     );
+    expect(
+      headerAvatarLabelElement.classList.contains(
+        GlobalClassName.VISUALLY_HIDDEN
+      )
+    ).toBe(true);
 
     const firstSpinResult = simulateSpinAndReveal(DishDescriptor.FIRST_ROUND);
     expect(firstSpinResult.hasTriggeringIngredient).toBe(true);
@@ -444,6 +458,11 @@ describe("Avatar selection persistence", () => {
     expect(headerAvatarLabelElement.textContent).toBe(
       expectedAvatarDescriptor.displayName
     );
+    expect(
+      headerAvatarLabelElement.classList.contains(
+        GlobalClassName.VISUALLY_HIDDEN
+      )
+    ).toBe(true);
     expect(headerAvatarImageElement.getAttribute(HtmlAttributeName.ALT)).toBe(
       `${expectedAvatarDescriptor.displayName}${AvatarMenuText.TOGGLE_ALT_SUFFIX}`
     );


### PR DESCRIPTION
## Summary
- hide the header avatar toggle label by marking it visually hidden while keeping the icon visible
- adjust the header toggle styling to center the icon without extra gap when text is hidden
- update avatar selection integration tests to confirm the header label stays hidden and menu options remain visible

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ccebd238c08327bcf9b5f5cbcc67d2