### PR TITLE
Improve medium breakpoint header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,11 +78,61 @@
 
         header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         .header-left { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
-        .header-right { display: flex; align-items: center; gap: 12px; }
+        .aw-header-title-group { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+        .header-right { display: flex; align-items: center; gap: 12px; justify-content: flex-end; flex-wrap: wrap; }
+        .aw-header-controls { display: flex; align-items: center; gap: 12px; justify-content: flex-end; flex-wrap: wrap; }
+        .aw-hearts-container { display: flex; align-items: center; }
         .header-nav { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
         .header-nav .ghost { min-width: 80px; text-align: center; }
 
         .avatar-menu-wrapper { position: relative; z-index: 70; }
+
+        @media (min-width: 768px) and (max-width: 1199px) {
+            header {
+                display: grid;
+                grid-template-columns: minmax(0, 1fr) auto;
+                grid-template-areas:
+                    "header-left header-controls"
+                    "header-hearts header-hearts";
+                align-items: center;
+                column-gap: 20px;
+                row-gap: 12px;
+            }
+
+            .header-left {
+                grid-area: header-left;
+                align-items: flex-start;
+                min-width: 0;
+            }
+
+            .aw-header-title-group {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 8px;
+            }
+
+            .header-right { display: contents; }
+
+            .aw-header-controls {
+                grid-area: header-controls;
+                justify-content: flex-end;
+                gap: 16px;
+            }
+
+            .aw-header-controls .ghost { flex: 0 0 auto; }
+
+            .aw-hearts-container {
+                grid-area: header-hearts;
+                width: 100%;
+                justify-content: center;
+            }
+
+            #hearts-bar {
+                width: 100%;
+                box-sizing: border-box;
+                justify-content: center;
+            }
+        }
 
         .avatar-menu-backdrop {
             position: fixed;
@@ -958,33 +1008,39 @@
             <div aria-hidden="true" class="avatar-menu-backdrop" id="avatar-menu-backdrop" hidden></div>
             <div class="avatar-menu" id="avatar-menu" hidden></div>
         </div>
-        <h1>Allergy Wheel</h1>
-        <div aria-label="Select a view" class="header-nav" role="group">
-            <button
-                aria-pressed="true"
-                class="ghost"
-                id="nav-game"
-                type="button"
-            >
-                Game
-            </button>
-            <button
-                aria-pressed="false"
-                class="ghost"
-                id="nav-menu"
-                type="button"
-            >
-                Menu
-            </button>
+        <div class="aw-header-title-group">
+            <h1>Allergy Wheel</h1>
+            <div aria-label="Select a view" class="header-nav" role="group">
+                <button
+                    aria-pressed="true"
+                    class="ghost"
+                    id="nav-game"
+                    type="button"
+                >
+                    Game
+                </button>
+                <button
+                    aria-pressed="false"
+                    class="ghost"
+                    id="nav-menu"
+                    type="button"
+                >
+                    Menu
+                </button>
+            </div>
         </div>
     </div>
     <div class="header-right">
-        <div aria-live="polite" class="hearts" data-count="0" id="hearts-bar" aria-label="0 hearts" title="0 hearts">
-            <span class="heart-count">0</span>
-            <span aria-hidden="true" class="heart-icons"></span>
+        <div class="aw-hearts-container">
+            <div aria-live="polite" class="hearts" data-count="0" id="hearts-bar" aria-label="0 hearts" title="0 hearts">
+                <span class="heart-count">0</span>
+                <span aria-hidden="true" class="heart-icons"></span>
+            </div>
         </div>
-        <button class="ghost" id="fs">Full Screen</button>
-        <button type="button" class="ghost" id="mute" aria-pressed="false" aria-label="Mute audio">Mute</button>
+        <div class="aw-header-controls">
+            <button class="ghost" id="fs">Full Screen</button>
+            <button type="button" class="ghost" id="mute" aria-pressed="false" aria-label="Mute audio">Mute</button>
+        </div>
     </div>
 </header>
 


### PR DESCRIPTION
## Summary
- add `aw-` prefixed wrappers to separate the header title/nav group and hearts bar for targeted styling
- adjust the medium-width header layout to use CSS grid so the avatar/title/nav remain left, controls move right, and the hearts bar spans a second row with balanced spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdeac0c5188327af6a9b6a33cd861e