### PR TITLE
Add mobile bottom navigation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
         .aw-header-controls { display: flex; align-items: center; gap: 12px; justify-content: flex-end; flex-wrap: wrap; }
         .aw-hearts-container { display: flex; align-items: center; }
         .header-nav { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .aw-bottombar { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
         .header-nav .ghost { min-width: 80px; text-align: center; }
 
         .avatar-menu-wrapper { position: relative; z-index: 70; }
@@ -131,6 +132,125 @@
                 width: 100%;
                 box-sizing: border-box;
                 justify-content: center;
+            }
+        }
+
+        @media (max-width: 767px) {
+            header {
+                display: grid;
+                grid-template-columns: auto 1fr auto;
+                grid-template-rows: auto auto auto;
+                align-items: center;
+                column-gap: 12px;
+                row-gap: 12px;
+                padding-top: 12px;
+                padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+                padding-left: calc(16px + env(safe-area-inset-left, 0px));
+                padding-right: calc(16px + env(safe-area-inset-right, 0px));
+            }
+
+            .header-left,
+            .header-right {
+                display: contents;
+            }
+
+            .avatar-menu-wrapper {
+                grid-column: 1;
+                grid-row: 1;
+            }
+
+            .aw-header-title-group {
+                grid-column: 2;
+                grid-row: 1;
+                justify-self: center;
+                text-align: center;
+                min-width: 0;
+            }
+
+            .aw-header-title-group h1 {
+                width: 100%;
+            }
+
+            .aw-header-controls {
+                grid-column: 3;
+                grid-row: 1;
+                justify-self: end;
+                gap: 10px;
+            }
+
+            .aw-header-controls .ghost,
+            #fs,
+            #mute {
+                min-height: 44px;
+                min-width: 44px;
+            }
+
+            .aw-hearts-container {
+                grid-column: 1 / -1;
+                grid-row: 2;
+                width: 100%;
+                justify-content: center;
+            }
+
+            #hearts-bar {
+                width: 100%;
+                box-sizing: border-box;
+                justify-content: center;
+            }
+
+            .aw-bottombar {
+                grid-column: 1 / -1;
+                grid-row: 3;
+                position: sticky;
+                bottom: env(safe-area-inset-bottom, 0px);
+                padding: 10px 16px calc(10px + env(safe-area-inset-bottom, 0px));
+                background: linear-gradient(90deg, #fff0d6, #ffe5f0);
+                border-top: 2px solid #ffd6e3;
+                box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.08);
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                gap: 12px;
+                z-index: 55;
+            }
+
+            .aw-bottombar .header-nav {
+                width: 100%;
+                justify-content: space-between;
+                gap: 12px;
+            }
+
+            .aw-bottombar .ghost {
+                flex: 1 1 0;
+                min-height: 44px;
+                min-width: 44px;
+                padding: 10px 12px;
+                font-size: 16px;
+            }
+
+            @media (max-width: 360px) {
+                header {
+                    column-gap: 8px;
+                }
+
+                .aw-header-title-group h1 {
+                    font-size: 18px;
+                    line-height: 1.15;
+                    word-break: keep-all;
+                }
+
+                .aw-bottombar .header-nav {
+                    gap: 8px;
+                }
+
+                .aw-bottombar .ghost {
+                    font-size: 15px;
+                    padding-inline: 8px;
+                }
+
+                .heart-icons {
+                    gap: 2px;
+                }
             }
         }
 
@@ -1010,6 +1130,8 @@
         </div>
         <div class="aw-header-title-group">
             <h1>Allergy Wheel</h1>
+        </div>
+        <div class="aw-bottombar">
             <div aria-label="Select a view" class="header-nav" role="group">
                 <button
                     aria-pressed="true"


### PR DESCRIPTION
## Summary
- add a dedicated bottom navigation container in the header so the existing Game/Menu controls can be reused in different layouts
- implement a mobile grid layout for the header that places the avatar, title, controls, hearts bar, and sticky bottom navigation as specified
- tune very small viewports to keep the title and heart icons readable without forcing horizontal scrolling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdebc585288327824d723fbd1b740c