### PR TITLE
Add wheel continue and restart controls

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -115,7 +115,8 @@ export const AudioAssetPath = Object.freeze({
 
 export const ControlElementId = Object.freeze({
     START_BUTTON: "start",
-    STOP_BUTTON: "stop",
+    WHEEL_CONTINUE_BUTTON: "wheel-continue",
+    WHEEL_RESTART_BUTTON: "wheel-restart",
     FULLSCREEN_BUTTON: "fs",
     MUTE_BUTTON: "mute",
     SPIN_AGAIN_BUTTON: "again",
@@ -260,7 +261,7 @@ export const KeyboardKey = Object.freeze({
 });
 
 export const ButtonText = Object.freeze({
-    START: "Start",
+    CONTINUE: "CONTINUE",
     STOP: "STOP",
     RESTART: "Restart",
     MUTE: "Mute",

--- a/game.js
+++ b/game.js
@@ -795,8 +795,10 @@ export class GameController {
     }
 
     #applyStartMode() {
-        const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
-        if (!centerButton) {
+        const wheelContinueButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_CONTINUE_BUTTON
+        );
+        if (!wheelContinueButtonElement) {
             if (this.#stateManager.setStopButtonMode) {
                 this.#stateManager.setStopButtonMode(WheelControlMode.START);
             }
@@ -805,9 +807,13 @@ export class GameController {
             }
             return;
         }
-        centerButton.textContent = ButtonText.START;
-        centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.START);
-        centerButton.classList.remove(ButtonClassName.STOP, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
+        wheelContinueButtonElement.textContent = ButtonText.CONTINUE;
+        wheelContinueButtonElement.classList.add(ButtonClassName.ACTION, ButtonClassName.START);
+        wheelContinueButtonElement.classList.remove(
+            ButtonClassName.STOP,
+            ButtonClassName.PRIMARY,
+            ButtonClassName.DANGER
+        );
         if (this.#stateManager.setStopButtonMode) {
             this.#stateManager.setStopButtonMode(WheelControlMode.START);
         }
@@ -817,8 +823,10 @@ export class GameController {
     }
 
     #applyStopMode() {
-        const centerButton = this.#documentReference.getElementById(this.#controlElementIdMap.STOP_BUTTON);
-        if (!centerButton) {
+        const wheelContinueButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_CONTINUE_BUTTON
+        );
+        if (!wheelContinueButtonElement) {
             if (this.#stateManager.setStopButtonMode) {
                 this.#stateManager.setStopButtonMode(WheelControlMode.STOP);
             }
@@ -827,9 +835,13 @@ export class GameController {
             }
             return;
         }
-        centerButton.textContent = ButtonText.STOP;
-        centerButton.classList.add(ButtonClassName.ACTION, ButtonClassName.STOP);
-        centerButton.classList.remove(ButtonClassName.START, ButtonClassName.PRIMARY, ButtonClassName.DANGER);
+        wheelContinueButtonElement.textContent = ButtonText.STOP;
+        wheelContinueButtonElement.classList.add(ButtonClassName.ACTION, ButtonClassName.STOP);
+        wheelContinueButtonElement.classList.remove(
+            ButtonClassName.START,
+            ButtonClassName.PRIMARY,
+            ButtonClassName.DANGER
+        );
         if (this.#stateManager.setStopButtonMode) {
             this.#stateManager.setStopButtonMode(WheelControlMode.STOP);
         }

--- a/index.html
+++ b/index.html
@@ -1086,9 +1086,57 @@
             width: 100%; height: 100%; background: #fff; border-radius: 50%;
             border: 6px solid #000; box-shadow: var(--shadow)
         }
-        #stop {
-            position: absolute; inset: auto auto 50% 50%; transform: translate(-50%, 50%);
-            padding: 22px 34px; border-radius: 999px; font-weight: 900; font-size: clamp(18px, 2.6vw, 28px)
+        #wheel-control {
+            position: absolute;
+            inset: auto auto 50% 50%;
+            transform: translate(-50%, 50%);
+            display: grid;
+            grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr);
+            align-items: stretch;
+            gap: 0;
+            background: #fff;
+            border-radius: 999px;
+            border: 4px solid #000;
+            box-shadow: 4px 6px 0 #000;
+            overflow: hidden;
+            min-width: clamp(240px, 42vmin, 400px);
+        }
+
+        #wheel-control .btn.action {
+            border: 0;
+            border-radius: 0;
+            box-shadow: none;
+        }
+
+        .wheel-control__continue {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 100%;
+            padding: clamp(18px, 3.5vmin, 28px) clamp(26px, 4.8vmin, 36px);
+            font-weight: 900;
+            font-size: clamp(18px, 2.6vw, 28px);
+        }
+
+        .wheel-control__restart {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background: #ffe08a;
+            color: #000;
+            border: 0;
+            border-left: 4px solid #000;
+            font-weight: 800;
+            font-size: clamp(14px, 1.8vw, 20px);
+            letter-spacing: 0.04em;
+            line-height: 1;
+            padding: clamp(14px, 2.8vmin, 22px) clamp(16px, 3.2vmin, 24px);
+            text-transform: uppercase;
+        }
+
+        .wheel-control__restart:focus-visible {
+            outline: 3px solid var(--ink);
+            outline-offset: -3px;
         }
 
         .status { text-align: center; margin-top: 12px; font-weight: 700 }
@@ -1201,8 +1249,13 @@
 <main id="screen-wheel">
     <div class="wheel-wrap">
         <canvas aria-label="Spinning dish wheel" height="1000" id="wheel" width="1000"></canvas>
-        <!-- unified action button; JS toggles .is-stop <-> .is-start -->
-        <button class="btn action is-stop" id="stop">STOP</button>
+        <!-- wheel control cluster; JS toggles .is-stop <-> .is-start on the main button -->
+        <div class="wheel-control" id="wheel-control">
+            <button class="wheel-control__continue btn action is-stop" id="wheel-continue" type="button">
+                STOP
+            </button>
+            <button class="wheel-control__restart" id="wheel-restart" type="button">Restart</button>
+        </div>
     </div>
     <div class="status">Allergens: <span id="sel-badges"></span></div>
 </main>

--- a/listeners.js
+++ b/listeners.js
@@ -75,9 +75,11 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     }
 
     function wireStopButton({ onStopRequested, onShowAllergyScreen }) {
-        const stopButton = documentReference.getElementById(controlElementId.STOP_BUTTON);
-        if (!stopButton) return;
-        stopButton.addEventListener(BrowserEventName.CLICK, () => {
+        const wheelContinueButton = documentReference.getElementById(
+            controlElementId.WHEEL_CONTINUE_BUTTON
+        );
+        if (!wheelContinueButton) return;
+        wheelContinueButton.addEventListener(BrowserEventName.CLICK, () => {
             if (stateManager.getStopButtonMode() === WheelControlMode.STOP) {
                 if (typeof onStopRequested === "function") onStopRequested();
             } else if (typeof onShowAllergyScreen === "function") {
@@ -161,19 +163,31 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     }
 
     function wireRestartButton({ onRestart }) {
-        const restartButton = documentReference.getElementById(controlElementId.RESTART_BUTTON);
-        if (!restartButton) return;
-        restartButton.addEventListener(BrowserEventName.CLICK, () => {
-            const gameOverSection = documentReference.getElementById(controlElementId.GAME_OVER_SECTION);
-            if (gameOverSection) {
-                gameOverSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+        const restartControlIdentifiers = [
+            controlElementId.RESTART_BUTTON,
+            controlElementId.WHEEL_RESTART_BUTTON
+        ];
+
+        for (const restartControlId of restartControlIdentifiers) {
+            if (!restartControlId) {
+                continue;
             }
-            const revealSection = documentReference.getElementById(controlElementId.REVEAL_SECTION);
-            if (revealSection) {
-                revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+            const restartButtonElement = documentReference.getElementById(restartControlId);
+            if (!restartButtonElement) {
+                continue;
             }
-            if (typeof onRestart === "function") onRestart();
-        });
+            restartButtonElement.addEventListener(BrowserEventName.CLICK, () => {
+                const gameOverSection = documentReference.getElementById(controlElementId.GAME_OVER_SECTION);
+                if (gameOverSection) {
+                    gameOverSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+                }
+                const revealSection = documentReference.getElementById(controlElementId.REVEAL_SECTION);
+                if (revealSection) {
+                    revealSection.setAttribute(attributeName.ARIA_HIDDEN, AttributeBooleanValue.TRUE);
+                }
+                if (typeof onRestart === "function") onRestart();
+            });
+        }
     }
 
     /**

--- a/tests/integration/gameController.integration.test.js
+++ b/tests/integration/gameController.integration.test.js
@@ -265,9 +265,12 @@ function createDomSkeleton() {
     <div id="${DocumentElementId.LOAD_ERROR}"></div>
     <div id="wheel-wrapper">
       <canvas id="${DocumentElementId.WHEEL_CANVAS}"></canvas>
+      <div id="wheel-control">
+        <button id="${ControlElementId.WHEEL_CONTINUE_BUTTON}"></button>
+        <button id="${ControlElementId.WHEEL_RESTART_BUTTON}"></button>
+      </div>
     </div>
     <button id="${ControlElementId.START_BUTTON}"></button>
-    <button id="${ControlElementId.STOP_BUTTON}"></button>
     <button id="${ControlElementId.FULLSCREEN_BUTTON}"></button>
     <button id="${ControlElementId.MUTE_BUTTON}" aria-pressed="false"></button>
     <button id="${ControlElementId.SPIN_AGAIN_BUTTON}"></button>


### PR DESCRIPTION
## Summary
- replace the wheel's single stop button with a two-button control cluster and updated styling that keeps the control centered and emphasizes the continue region
- add descriptive wheel control identifiers and a CONTINUE label constant while updating listeners and the game controller to target the new buttons
- refresh the integration DOM skeleton to expose the new wheel controls during tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf1c970ec8327b6e7c07ff5ca81eb