### PR TITLE
Add restart confirmation modal flow

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -128,7 +128,19 @@ export const ControlElementId = Object.freeze({
     AVATAR_MENU_BACKDROP: "avatar-menu-backdrop",
     ALLERGY_TITLE: "allergy-title",
     NAV_GAME_BUTTON: "nav-game",
-    NAV_MENU_BUTTON: "nav-menu"
+    NAV_MENU_BUTTON: "nav-menu",
+    RESTART_CONFIRMATION_CONTAINER: "restart-confirmation",
+    RESTART_CONFIRMATION_OVERLAY: "restart-confirmation-overlay",
+    RESTART_CONFIRMATION_DIALOG: "restart-confirmation-dialog",
+    RESTART_CONFIRMATION_CONFIRM_BUTTON: "restart-confirmation-confirm",
+    RESTART_CONFIRMATION_CANCEL_BUTTON: "restart-confirmation-cancel"
+});
+
+export const RestartConfirmationText = Object.freeze({
+    TITLE: "Restart the game?",
+    MESSAGE: "Are you sure you want to restart? Your current progress will be lost.",
+    CONFIRM: "Yes, restart",
+    CANCEL: "Continue playing"
 });
 
 const AvatarButtonClassName = "avatar-button";

--- a/game.js
+++ b/game.js
@@ -520,6 +520,12 @@ export class GameController {
                     if (typeof this.#uiPresenter.openRestartConfirmation === "function") {
                         this.#uiPresenter.openRestartConfirmation();
                     }
+                },
+                onRestartConfirmed: () => {
+                    if (this.#wheel && typeof this.#wheel.stop === "function") {
+                        this.#wheel.stop();
+                    }
+                    this.#resetGame();
                 }
             });
         }

--- a/index.html
+++ b/index.html
@@ -1081,6 +1081,38 @@
         #gameover { position: fixed; inset: 0; background: rgba(0,0,0,.6); display: none; place-items: center; z-index: 20; }
         #gameover[aria-hidden="false"] { display: grid; }
 
+        .restart-modal { position: fixed; inset: 0; display: none; place-items: center; padding: clamp(12px, 4vmin, 24px); z-index: 30; }
+        .restart-modal:not([hidden]) { display: grid; }
+        .restart-modal__overlay { position: absolute; inset: 0; background: rgba(17, 17, 17, 0.55); }
+        .restart-modal__dialog {
+            position: relative;
+            background: var(--card);
+            border: 4px solid #000;
+            border-radius: 28px;
+            box-shadow: var(--shadow);
+            padding: clamp(20px, 3.6vmin, 32px);
+            width: min(420px, 92vw);
+            display: grid;
+            gap: clamp(16px, 3vmin, 24px);
+        }
+        .restart-modal__title { margin: 0; font-size: clamp(20px, 2.6vw, 32px); text-align: center; }
+        .restart-modal__message { margin: 0; color: var(--muted); font-size: clamp(16px, 2.2vw, 20px); line-height: 1.5; text-align: center; }
+        .restart-modal__actions { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
+        .restart-modal__confirm,
+        .restart-modal__cancel {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            flex: 1 1 160px;
+        }
+        .restart-modal__cancel { text-transform: uppercase; font-weight: 800; }
+
+        @media (min-width: 600px) {
+            .restart-modal__actions { justify-content: flex-end; }
+            .restart-modal__title,
+            .restart-modal__message { text-align: left; }
+        }
+
         .wheel-wrap { position: relative; width: min(96vmin, 980px); aspect-ratio: 1; display: grid; place-items: center; margin-inline: auto }
         #wheel {
             width: 100%; height: 100%; background: #fff; border-radius: 50%;
@@ -1258,6 +1290,36 @@
         </div>
     </div>
     <div class="status">Allergens: <span id="sel-badges"></span></div>
+    <div
+        aria-hidden="true"
+        class="restart-modal"
+        hidden
+        id="restart-confirmation"
+    >
+        <div class="restart-modal__overlay" id="restart-confirmation-overlay"></div>
+        <div
+            aria-describedby="restart-confirmation-description"
+            aria-labelledby="restart-confirmation-title"
+            aria-modal="true"
+            class="restart-modal__dialog"
+            id="restart-confirmation-dialog"
+            role="dialog"
+            tabindex="-1"
+        >
+            <h2 class="restart-modal__title" id="restart-confirmation-title">Restart the game?</h2>
+            <p class="restart-modal__message" id="restart-confirmation-description">
+                Are you sure you want to restart? Your current progress will be lost.
+            </p>
+            <div class="restart-modal__actions">
+                <button class="btn danger restart-modal__confirm" id="restart-confirmation-confirm" type="button">
+                    Yes, restart
+                </button>
+                <button class="ghost restart-modal__cancel" id="restart-confirmation-cancel" type="button">
+                    Continue playing
+                </button>
+            </div>
+        </div>
+    </div>
 </main>
 
 <!-- Menu -->

--- a/tests/integration/restartConfirmation.integration.test.js
+++ b/tests/integration/restartConfirmation.integration.test.js
@@ -1,0 +1,192 @@
+import { jest } from "@jest/globals";
+import { createListenerBinder } from "../../listeners.js";
+import {
+  AttributeBooleanValue,
+  AttributeName,
+  BrowserEventName,
+  ControlElementId,
+  KeyboardKey,
+  RestartConfirmationText,
+  WheelControlMode
+} from "../../constants.js";
+
+const RestartModalScenarioDescription = Object.freeze({
+  PRESENTS_DIALOG: "displays the restart confirmation modal and focuses the dialog",
+  DISMISS_ESCAPE: "closes the restart confirmation modal when Escape is pressed",
+  DISMISS_OVERLAY: "closes the restart confirmation modal when the overlay is clicked",
+  DISMISS_CONTINUE: "closes the restart confirmation modal when Continue is activated",
+  CONFIRM_RESTART: "confirms the restart request when Yes is activated"
+});
+
+function createStateManagerDouble() {
+  return {
+    hasSelectedAllergen: jest.fn(() => true),
+    getWheelControlMode: jest.fn(() => WheelControlMode.START),
+    isAudioMuted: jest.fn(() => false),
+    toggleAudioMuted: jest.fn(() => false)
+  };
+}
+
+function initializeRestartModalDom() {
+  document.body.innerHTML = `
+    <section id="${ControlElementId.REVEAL_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
+    <section id="${ControlElementId.GAME_OVER_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
+    <button id="${ControlElementId.WHEEL_RESTART_BUTTON}" type="button">Restart</button>
+    <div
+      aria-hidden="${AttributeBooleanValue.TRUE}"
+      hidden
+      id="${ControlElementId.RESTART_CONFIRMATION_CONTAINER}"
+    >
+      <div id="${ControlElementId.RESTART_CONFIRMATION_OVERLAY}"></div>
+      <div
+        aria-hidden="${AttributeBooleanValue.TRUE}"
+        id="${ControlElementId.RESTART_CONFIRMATION_DIALOG}"
+        role="dialog"
+        tabindex="-1"
+      >
+        <h2 id="restart-confirmation-title">${RestartConfirmationText.TITLE}</h2>
+        <p id="restart-confirmation-description">${RestartConfirmationText.MESSAGE}</p>
+        <div>
+          <button id="${ControlElementId.RESTART_CONFIRMATION_CONFIRM_BUTTON}" type="button">
+            ${RestartConfirmationText.CONFIRM}
+          </button>
+          <button id="${ControlElementId.RESTART_CONFIRMATION_CANCEL_BUTTON}" type="button">
+            ${RestartConfirmationText.CANCEL}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+describe("Restart confirmation modal interactions", () => {
+  test(RestartModalScenarioDescription.PRESENTS_DIALOG, () => {
+    initializeRestartModalDom();
+    const stateManager = createStateManagerDouble();
+    const listenerBinder = createListenerBinder({
+      controlElementId: ControlElementId,
+      attributeName: AttributeName,
+      documentReference: document,
+      stateManager
+    });
+
+    const restartRequestedSpy = jest.fn();
+    const restartConfirmedSpy = jest.fn();
+
+    listenerBinder.wireWheelRestartButton({
+      onRestartRequested: restartRequestedSpy,
+      onRestartConfirmed: restartConfirmedSpy
+    });
+
+    const restartButton = document.getElementById(ControlElementId.WHEEL_RESTART_BUTTON);
+    const modalContainer = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CONTAINER);
+    const modalDialog = document.getElementById(ControlElementId.RESTART_CONFIRMATION_DIALOG);
+    const confirmButton = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CONFIRM_BUTTON);
+    const continueButton = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CANCEL_BUTTON);
+
+    restartButton.click();
+
+    expect(modalContainer.hidden).toBe(false);
+    expect(modalContainer.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.FALSE);
+    expect(modalDialog.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.FALSE);
+    expect(document.activeElement).toBe(modalDialog);
+    expect(restartRequestedSpy).toHaveBeenCalledTimes(1);
+    expect(confirmButton.textContent.trim()).toBe(RestartConfirmationText.CONFIRM);
+    expect(continueButton.textContent.trim()).toBe(RestartConfirmationText.CANCEL);
+  });
+
+  const RestartModalDismissalScenarios = [
+    {
+      description: RestartModalScenarioDescription.DISMISS_ESCAPE,
+      triggerDismissal: () => {
+        const escapeEvent = new KeyboardEvent(BrowserEventName.KEY_DOWN, {
+          key: KeyboardKey.ESCAPE,
+          bubbles: true
+        });
+        document.dispatchEvent(escapeEvent);
+      }
+    },
+    {
+      description: RestartModalScenarioDescription.DISMISS_OVERLAY,
+      triggerDismissal: ({ overlayElement }) => {
+        overlayElement.click();
+      }
+    },
+    {
+      description: RestartModalScenarioDescription.DISMISS_CONTINUE,
+      triggerDismissal: ({ continueButton }) => {
+        continueButton.click();
+      }
+    }
+  ];
+
+  test.each(RestartModalDismissalScenarios)(
+    "%s",
+    ({ triggerDismissal }) => {
+      initializeRestartModalDom();
+      const stateManager = createStateManagerDouble();
+      const listenerBinder = createListenerBinder({
+        controlElementId: ControlElementId,
+        attributeName: AttributeName,
+        documentReference: document,
+        stateManager
+      });
+
+      const restartConfirmedSpy = jest.fn();
+
+      listenerBinder.wireWheelRestartButton({
+        onRestartConfirmed: restartConfirmedSpy
+      });
+
+      const restartButton = document.getElementById(ControlElementId.WHEEL_RESTART_BUTTON);
+      const modalContainer = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CONTAINER);
+      const modalDialog = document.getElementById(ControlElementId.RESTART_CONFIRMATION_DIALOG);
+      const overlayElement = document.getElementById(ControlElementId.RESTART_CONFIRMATION_OVERLAY);
+      const continueButton = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CANCEL_BUTTON);
+
+      restartButton.click();
+
+      triggerDismissal({ overlayElement, continueButton });
+
+      expect(modalContainer.hidden).toBe(true);
+      expect(modalContainer.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+      expect(modalDialog.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+      expect(document.activeElement).toBe(restartButton);
+      expect(restartConfirmedSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  test(RestartModalScenarioDescription.CONFIRM_RESTART, () => {
+    initializeRestartModalDom();
+    const stateManager = createStateManagerDouble();
+    const listenerBinder = createListenerBinder({
+      controlElementId: ControlElementId,
+      attributeName: AttributeName,
+      documentReference: document,
+      stateManager
+    });
+
+    const restartConfirmedSpy = jest.fn();
+
+    listenerBinder.wireWheelRestartButton({
+      onRestartConfirmed: restartConfirmedSpy
+    });
+
+    const restartButton = document.getElementById(ControlElementId.WHEEL_RESTART_BUTTON);
+    const confirmButton = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CONFIRM_BUTTON);
+    const modalContainer = document.getElementById(ControlElementId.RESTART_CONFIRMATION_CONTAINER);
+    const modalDialog = document.getElementById(ControlElementId.RESTART_CONFIRMATION_DIALOG);
+    const revealSection = document.getElementById(ControlElementId.REVEAL_SECTION);
+    const gameOverSection = document.getElementById(ControlElementId.GAME_OVER_SECTION);
+
+    restartButton.click();
+    confirmButton.click();
+
+    expect(restartConfirmedSpy).toHaveBeenCalledTimes(1);
+    expect(revealSection.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+    expect(gameOverSection.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+    expect(modalContainer.hidden).toBe(true);
+    expect(modalContainer.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+    expect(modalDialog.getAttribute(AttributeName.ARIA_HIDDEN)).toBe(AttributeBooleanValue.TRUE);
+  });
+});


### PR DESCRIPTION
## Summary
- add restart confirmation modal markup and styling to the wheel screen
- wire restart confirmation logic through constants, listeners, and the game controller
- expand unit and integration coverage for modal presentation, dismissal, and confirmation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdf78c95248327935c9e5e2bda5245