### PR TITLE
Ensure bootstrap runs when DOM is ready

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ import {
     AttributeName,
     AttributeBooleanValue,
     BrowserEventName,
+    DocumentReadyState,
     FirstCardElementId,
     ResultCardElementId,
     AvatarId,
@@ -316,6 +317,10 @@ listenerBinder.wireAvatarSelector({
 
 updateHeaderAvatarSelection(stateManager.getSelectedAvatar());
 
-window.addEventListener(BrowserEventName.DOM_CONTENT_LOADED, () => {
+if (document.readyState !== DocumentReadyState.LOADING) {
+    gameController.bootstrap();
+}
+
+document.addEventListener(BrowserEventName.DOM_CONTENT_LOADED, () => {
     gameController.bootstrap();
 });

--- a/constants.js
+++ b/constants.js
@@ -260,6 +260,16 @@ export const AttributeBooleanValue = Object.freeze({
     FALSE: "false"
 });
 
+const DocumentReadyStateLoading = "loading";
+const DocumentReadyStateInteractive = "interactive";
+const DocumentReadyStateComplete = "complete";
+
+export const DocumentReadyState = Object.freeze({
+    LOADING: DocumentReadyStateLoading,
+    INTERACTIVE: DocumentReadyStateInteractive,
+    COMPLETE: DocumentReadyStateComplete
+});
+
 export const BrowserEventName = Object.freeze({
     DOM_CONTENT_LOADED: "DOMContentLoaded",
     CLICK: "click",


### PR DESCRIPTION
## Summary
- add a constant describing document ready states so DOM readiness checks do not rely on literals
- ensure the game controller bootstraps immediately when the DOM is already parsed and when DOMContentLoaded fires

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ce04d0d62083279165d18a09c93b0f