### PR TITLE
Initialize wheel control in start mode

### DIFF
--- a/game.js
+++ b/game.js
@@ -268,6 +268,7 @@ export class GameController {
             this.#initializeSelectionUi(gameData.allergensCatalog);
             this.#configureWheel();
             this.#wireControlListeners();
+            this.#applyStartMode();
             this.#finalizeBootstrap();
         } catch (errorObject) {
             this.#handleBootstrapError(errorObject);

--- a/index.html
+++ b/index.html
@@ -1283,8 +1283,13 @@
         <canvas aria-label="Spinning dish wheel" height="1000" id="wheel" width="1000"></canvas>
         <!-- wheel control cluster; JS toggles .is-stop <-> .is-start on the main button -->
         <div class="wheel-control" id="wheel-control">
-            <button class="wheel-control__continue btn action is-stop" id="wheel-continue" type="button">
-                STOP
+            <button
+                class="wheel-control__continue btn action is-start"
+                data-wheel-control-mode="start"
+                id="wheel-continue"
+                type="button"
+            >
+                CONTINUE
             </button>
             <button class="wheel-control__restart" id="wheel-restart" type="button">Restart</button>
         </div>


### PR DESCRIPTION
## Summary
- ensure GameController.bootstrap applies the start mode so the wheel control and state manager default to the continue state on load
- update the wheel control markup to use the start styling and label so the HTML matches the initialized state

## Testing
- npm test
- Manual: navigated to the wheel screen before spinning and confirmed the control reads CONTINUE and starts a spin

------
https://chatgpt.com/codex/tasks/task_e_68ce2771d28c8327ae3fc83c68374693