### PR TITLE
Guard game bootstrap from repeated invocations

### DIFF
--- a/app.js
+++ b/app.js
@@ -317,8 +317,20 @@ listenerBinder.wireAvatarSelector({
 
 updateHeaderAvatarSelection(stateManager.getSelectedAvatar());
 
+let hasGameBootstrapCompleted = false;
+
 const bootstrapGameWhenDocumentIsReady = () => {
+    if (hasGameBootstrapCompleted) {
+        return;
+    }
+
+    hasGameBootstrapCompleted = true;
     gameController.bootstrap();
+
+    document.removeEventListener(
+        BrowserEventName.DOM_CONTENT_LOADED,
+        bootstrapGameWhenDocumentIsReady
+    );
 };
 
 if (document.readyState !== DocumentReadyState.LOADING) {


### PR DESCRIPTION
## Summary
- ensure the game bootstrap handler is idempotent by guarding repeated calls and removing the DOMContentLoaded listener once it runs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce2cf6a7a48327a144e38c588f1444