### PR TITLE
Ensure restart control visibility follows reveal modal state

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -43,12 +43,18 @@ function applyWheelRestartButtonVisibility(wheelRestartButtonElement, shouldHide
 export function updateWheelRestartControlVisibilityFromRevealState() {
     const wheelRestartButtonElement = document.getElementById(ControlElementId.WHEEL_RESTART_BUTTON);
     if (!wheelRestartButtonElement) {
-        return false;
+        return {
+            didUpdateVisibility: false,
+            shouldHideRestartControl: isRevealSectionVisible()
+        };
     }
 
     const shouldHideButton = isRevealSectionVisible();
     applyWheelRestartButtonVisibility(wheelRestartButtonElement, shouldHideButton);
-    return true;
+    return {
+        didUpdateVisibility: true,
+        shouldHideRestartControl: shouldHideButton
+    };
 }
 
 const ScreenElementEntries = Object.freeze([
@@ -119,7 +125,7 @@ export function setWheelControlToStartGame() {
         wheelControlElement.classList.remove(WheelControlClassName.STOP_MODE);
     }
 
-    updateWheelRestartControlVisibilityFromRevealState();
+    return updateWheelRestartControlVisibilityFromRevealState();
 }
 
 export function openRestartConfirmation() {


### PR DESCRIPTION
## Summary
- centralize reveal modal dismissal in the listener binder so the wheel restart button remains hidden until the modal actually closes (spin again, backdrop clicks, Escape, restart flows)
- expose the reveal visibility result from the UI helper so callers can tell whether the restart control should stay hidden

## Testing
- npm test -- tests/integration/gameController.integration.test.js
- npm test -- tests/unit/listeners.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cee7852374832794886291b70d5c04