### PR TITLE
Refactor wheel control for combined spin and restart segment

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,5 +1,4 @@
 import {
-    ButtonText,
     ScreenName,
     WheelControlMode,
     BrowserEventName,
@@ -817,7 +816,14 @@ export class GameController {
         const wheelContinueButtonElement = this.#documentReference.getElementById(
             this.#controlElementIdMap.WHEEL_CONTINUE_BUTTON
         );
+        const wheelControlElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_CONTROL_CONTAINER
+        );
+        const wheelRestartButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_RESTART_BUTTON
+        );
         const wheelControlModeAttributeName = this.#attributeNameMap.DATA_WHEEL_CONTROL_MODE;
+        const ariaHiddenAttributeName = this.#attributeNameMap.ARIA_HIDDEN;
 
         if (!wheelContinueButtonElement) {
             if (this.#stateManager.setWheelControlMode) {
@@ -828,7 +834,6 @@ export class GameController {
             }
             return;
         }
-        wheelContinueButtonElement.textContent = ButtonText.SPIN;
         wheelContinueButtonElement.classList.add(ButtonClassName.ACTION, ButtonClassName.START);
         wheelContinueButtonElement.classList.remove(
             ButtonClassName.STOP,
@@ -836,10 +841,18 @@ export class GameController {
             ButtonClassName.DANGER
         );
         if (wheelControlModeAttributeName) {
-            wheelContinueButtonElement.setAttribute(
-                wheelControlModeAttributeName,
-                WheelControlMode.START
-            );
+            const wheelModeTargetElement = wheelControlElement || wheelContinueButtonElement;
+            wheelModeTargetElement.setAttribute(wheelControlModeAttributeName, WheelControlMode.START);
+        }
+        if (wheelRestartButtonElement) {
+            if (ariaHiddenAttributeName) {
+                wheelRestartButtonElement.setAttribute(
+                    ariaHiddenAttributeName,
+                    AttributeBooleanValue.FALSE
+                );
+            }
+            wheelRestartButtonElement.tabIndex = 0;
+            wheelRestartButtonElement.setAttribute("tabindex", "0");
         }
         if (this.#stateManager.setWheelControlMode) {
             this.#stateManager.setWheelControlMode(WheelControlMode.START);
@@ -853,7 +866,14 @@ export class GameController {
         const wheelContinueButtonElement = this.#documentReference.getElementById(
             this.#controlElementIdMap.WHEEL_CONTINUE_BUTTON
         );
+        const wheelControlElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_CONTROL_CONTAINER
+        );
+        const wheelRestartButtonElement = this.#documentReference.getElementById(
+            this.#controlElementIdMap.WHEEL_RESTART_BUTTON
+        );
         const wheelControlModeAttributeName = this.#attributeNameMap.DATA_WHEEL_CONTROL_MODE;
+        const ariaHiddenAttributeName = this.#attributeNameMap.ARIA_HIDDEN;
 
         if (!wheelContinueButtonElement) {
             if (this.#stateManager.setWheelControlMode) {
@@ -864,7 +884,6 @@ export class GameController {
             }
             return;
         }
-        wheelContinueButtonElement.textContent = ButtonText.STOP;
         wheelContinueButtonElement.classList.add(ButtonClassName.ACTION, ButtonClassName.STOP);
         wheelContinueButtonElement.classList.remove(
             ButtonClassName.START,
@@ -872,10 +891,18 @@ export class GameController {
             ButtonClassName.DANGER
         );
         if (wheelControlModeAttributeName) {
-            wheelContinueButtonElement.setAttribute(
-                wheelControlModeAttributeName,
-                WheelControlMode.STOP
-            );
+            const wheelModeTargetElement = wheelControlElement || wheelContinueButtonElement;
+            wheelModeTargetElement.setAttribute(wheelControlModeAttributeName, WheelControlMode.STOP);
+        }
+        if (wheelRestartButtonElement) {
+            if (ariaHiddenAttributeName) {
+                wheelRestartButtonElement.setAttribute(
+                    ariaHiddenAttributeName,
+                    AttributeBooleanValue.TRUE
+                );
+            }
+            wheelRestartButtonElement.tabIndex = -1;
+            wheelRestartButtonElement.setAttribute("tabindex", "-1");
         }
         if (this.#stateManager.setWheelControlMode) {
             this.#stateManager.setWheelControlMode(WheelControlMode.STOP);

--- a/index.html
+++ b/index.html
@@ -1122,8 +1122,7 @@
             position: absolute;
             inset: auto auto 50% 50%;
             transform: translate(-50%, 50%);
-            display: grid;
-            grid-template-columns: minmax(0, 2.5fr) minmax(0, 1fr);
+            display: inline-flex;
             align-items: stretch;
             gap: 0;
             background: #fff;
@@ -1132,18 +1131,6 @@
             box-shadow: 4px 6px 0 #000;
             overflow: hidden;
             min-width: clamp(240px, 42vmin, 400px);
-        }
-
-        #wheel-control.wheel-control--stop-mode {
-            grid-template-columns: minmax(0, 1fr);
-        }
-
-        #wheel-control.wheel-control--stop-mode .wheel-control__continue {
-            border-right: 0;
-        }
-
-        #wheel-control.wheel-control--stop-mode .wheel-control__restart {
-            border-left: 0;
         }
 
         #wheel-control .btn.action {
@@ -1160,6 +1147,25 @@
             padding: clamp(18px, 3.5vmin, 28px) clamp(26px, 4.8vmin, 36px);
             font-weight: 900;
             font-size: clamp(18px, 2.6vw, 28px);
+            gap: clamp(6px, 1.2vmin, 10px);
+            text-transform: uppercase;
+        }
+
+        .wheel-control__label {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            line-height: 1;
+        }
+
+        #wheel-control[data-wheel-control-mode="start"] .wheel-control__label--spin,
+        #wheel-control:not([data-wheel-control-mode]) .wheel-control__label--spin {
+            display: inline-flex;
+        }
+
+        #wheel-control[data-wheel-control-mode="stop"] .wheel-control__label--stop,
+        #wheel-control.wheel-control--stop-mode .wheel-control__label--stop {
+            display: inline-flex;
         }
 
         .wheel-control__restart {
@@ -1168,7 +1174,6 @@
             justify-content: center;
             background: #ffe08a;
             color: #000;
-            border: 0;
             border-left: 4px solid #000;
             font-weight: 800;
             font-size: clamp(14px, 1.8vw, 20px);
@@ -1176,6 +1181,23 @@
             line-height: 1;
             padding: clamp(14px, 2.8vmin, 22px) clamp(16px, 3.2vmin, 24px);
             text-transform: uppercase;
+            cursor: pointer;
+        }
+
+        #wheel-control[data-wheel-control-mode="stop"] .wheel-control__restart,
+        #wheel-control.wheel-control--stop-mode .wheel-control__restart,
+        .wheel-control__restart[aria-hidden="true"] {
+            display: none;
+        }
+
+        #wheel-control[data-wheel-control-mode="stop"],
+        #wheel-control.wheel-control--stop-mode {
+            min-width: clamp(200px, 34vmin, 320px);
+        }
+
+        #wheel-control[data-wheel-control-mode="stop"] .wheel-control__continue,
+        #wheel-control.wheel-control--stop-mode .wheel-control__continue {
+            padding-inline: clamp(28px, 5vmin, 44px);
         }
 
         .wheel-control__restart:focus-visible {
@@ -1294,16 +1316,20 @@
     <div class="wheel-wrap">
         <canvas aria-label="Spinning dish wheel" height="1000" id="wheel" width="1000"></canvas>
         <!-- wheel control cluster; JS toggles .is-stop <-> .is-start on the main button -->
-        <div class="wheel-control" id="wheel-control">
-            <button
-                class="wheel-control__continue btn action is-start"
-                data-wheel-control-mode="start"
-                id="wheel-continue"
-                type="button"
-            >
-                SPIN
+        <div class="wheel-control" data-wheel-control-mode="start" id="wheel-control">
+            <button class="wheel-control__continue btn action is-start" id="wheel-continue" type="button">
+                <span class="wheel-control__label wheel-control__label--spin">SPIN</span>
+                <span class="wheel-control__label wheel-control__label--stop">STOP</span>
             </button>
-            <button class="wheel-control__restart" id="wheel-restart" type="button">Restart</button>
+            <div
+                aria-hidden="false"
+                class="wheel-control__restart"
+                id="wheel-restart"
+                role="button"
+                tabindex="0"
+            >
+                Restart
+            </div>
         </div>
     </div>
     <div class="status">Allergens: <span id="sel-badges"></span></div>

--- a/listeners.js
+++ b/listeners.js
@@ -146,7 +146,13 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
 
             const modeAttributeName = attributeName.DATA_WHEEL_CONTROL_MODE;
             if (modeAttributeName) {
-                const attributeModeValue = wheelContinueButton.getAttribute(modeAttributeName);
+                const wheelControlContainer = documentReference.getElementById(
+                    controlElementId.WHEEL_CONTROL_CONTAINER
+                );
+                const attributeSourceElement = wheelControlContainer || wheelContinueButton;
+                const attributeModeValue = attributeSourceElement
+                    ? attributeSourceElement.getAttribute(modeAttributeName)
+                    : null;
                 if (attributeModeValue === WheelControlMode.STOP || attributeModeValue === WheelControlMode.START) {
                     return attributeModeValue;
                 }
@@ -172,10 +178,10 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
     }
 
     function wireWheelRestartButton({ onRestartRequested, onRestartConfirmed } = {}) {
-        const wheelRestartButton = documentReference.getElementById(
+        const wheelRestartSegmentElement = documentReference.getElementById(
             controlElementId.WHEEL_RESTART_BUTTON
         );
-        if (!wheelRestartButton) {
+        if (!wheelRestartSegmentElement) {
             return;
         }
 
@@ -248,7 +254,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
                 return true;
             }
 
-            restartConfirmationState.lastFocusedElement = wheelRestartButton;
+            restartConfirmationState.lastFocusedElement = wheelRestartSegmentElement;
 
             containerElement.hidden = false;
             if (ariaHiddenAttributeName) {
@@ -327,7 +333,7 @@ function createListenerBinder({ controlElementId, attributeName, documentReferen
 
         documentReference.addEventListener(BrowserEventName.KEY_DOWN, handleEscapeKeyDown);
 
-        addActivationListenersToButton(wheelRestartButton, handleRestartRequest);
+        addActivationListenersToButton(wheelRestartSegmentElement, handleRestartRequest);
     }
 
     function wireFullscreenButton() {

--- a/tests/integration/restartConfirmation.integration.test.js
+++ b/tests/integration/restartConfirmation.integration.test.js
@@ -31,7 +31,14 @@ function initializeRestartModalDom() {
   document.body.innerHTML = `
     <section id="${ControlElementId.REVEAL_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
     <section id="${ControlElementId.GAME_OVER_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
-    <button id="${ControlElementId.WHEEL_RESTART_BUTTON}" type="button">Restart</button>
+    <div
+      aria-hidden="${AttributeBooleanValue.FALSE}"
+      id="${ControlElementId.WHEEL_RESTART_BUTTON}"
+      role="button"
+      tabindex="0"
+    >
+      Restart
+    </div>
     <div
       aria-hidden="${AttributeBooleanValue.TRUE}"
       hidden

--- a/tests/unit/listeners.test.js
+++ b/tests/unit/listeners.test.js
@@ -45,7 +45,12 @@ function renderRestartModalSkeleton() {
   document.body.innerHTML = `
     <section id="${ControlElementId.REVEAL_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
     <section id="${ControlElementId.GAME_OVER_SECTION}" aria-hidden="${AttributeBooleanValue.FALSE}"></section>
-    <button id="${ControlElementId.WHEEL_RESTART_BUTTON}" type="button"></button>
+    <div
+      aria-hidden="${AttributeBooleanValue.FALSE}"
+      id="${ControlElementId.WHEEL_RESTART_BUTTON}"
+      role="button"
+      tabindex="0"
+    ></div>
     <div
       aria-hidden="${AttributeBooleanValue.TRUE}"
       hidden


### PR DESCRIPTION
## Summary
- restyle the wheel control as a single pill with embedded spin and restart segments
- update game, UI, and listener logic to toggle the new wheel control mode attribute and restart segment accessibility state
- refresh integration and unit tests to cover the state-driven wheel control DOM

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf266e790c8327845ba3972b4c4ba4