### PR TITLE
docs: centralize domain typedefs

### DIFF
--- a/js/core/app.js
+++ b/js/core/app.js
@@ -35,6 +35,10 @@ import {
     MenuElementId
 } from "../constants.js";
 
+/** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
+/** @typedef {import("../types.js").AllergenBadgeEntry} AllergenBadgeEntry */
+/** @typedef {import("../types.js").AvatarDescriptor} AvatarDescriptor */
+
 const stateManager = new StateManager();
 
 const listenerBinder = createListenerBinder({
@@ -92,6 +96,11 @@ menuFilterController.initialize();
 const firstCardPresenter = new AllergenCard({
     listContainerElement: document.getElementById(FirstCardElementId.LIST_CONTAINER),
     badgeContainerElement: document.getElementById(FirstCardElementId.BADGE_CONTAINER),
+    /**
+     * Handles allergen selection from the first card presenter.
+     *
+     * @param {AllergenDescriptor} allergenDescriptor - Descriptor representing the chosen allergen.
+     */
     onAllergenSelected: (allergenDescriptor) => {
         if (!allergenDescriptor || !allergenDescriptor.token) {
             return;
@@ -106,6 +115,7 @@ const firstCardPresenter = new AllergenCard({
 
         setDocumentStartButtonBlockedState(false);
 
+        /** @type {AllergenBadgeEntry} */
         const badgeEntry = {
             label: selectedLabel,
             emoji: allergenDescriptor.emoji || ""
@@ -121,8 +131,10 @@ const firstCardPresenter = new AllergenCard({
     }
 });
 
+/** @type {Map<string, AvatarDescriptor>} */
 const avatarDescriptorMap = buildAvatarDescriptorMap(AvatarCatalog);
 
+/** @type {Map<string, string>} */
 const avatarResourceMap = new Map();
 for (const avatarDescriptor of AvatarCatalog) {
     avatarResourceMap.set(avatarDescriptor.id, avatarDescriptor.assetPath);

--- a/js/core/board.js
+++ b/js/core/board.js
@@ -1,4 +1,14 @@
+/** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
+/** @typedef {import("../types.js").Dish} Dish */
+
 export class Board {
+    /**
+     * @param {{
+     *     allergensCatalog?: AllergenDescriptor[],
+     *     dishesCatalog?: Dish[],
+     *     normalizationEngine?: import("../utils/utils.js").NormalizationEngine | null
+     * }} [dependencies]
+     */
     constructor({ allergensCatalog, dishesCatalog, normalizationEngine }) {
         this.allergensCatalog = Array.isArray(allergensCatalog) ? allergensCatalog : [];
         this.dishesCatalog = Array.isArray(dishesCatalog) ? dishesCatalog : [];
@@ -6,6 +16,9 @@ export class Board {
         this.dishIndexByAllergen = new Map();
     }
 
+    /**
+     * Builds an index of dishes keyed by allergen token using the configured normalization engine.
+     */
     buildDishIndexByAllergen() {
         const localIndex = new Map();
         for (const dishObject of this.dishesCatalog) {
@@ -19,6 +32,9 @@ export class Board {
         this.dishIndexByAllergen = localIndex;
     }
 
+    /**
+     * Validates that each allergen token resolves at least one dish in the catalog.
+     */
     throwIfAnyAllergenHasNoDishes() {
         const missingTokens = [];
         for (const allergen of this.allergensCatalog) {
@@ -31,11 +47,23 @@ export class Board {
         }
     }
 
+    /**
+     * Retrieves dishes associated with the provided allergen token.
+     *
+     * @param {string} tokenValue - Allergen token used for lookup.
+     * @returns {Dish[]} Array of dishes that contain the allergen.
+     */
     getDishesForAllergen(tokenValue) {
         if (!tokenValue) return [];
         return this.dishIndexByAllergen.get(tokenValue) || [];
     }
 
+    /**
+     * Resolves a display label for the provided dish, considering several fallback fields.
+     *
+     * @param {Dish | null | undefined} dishObject - Dish entry requiring a human readable label.
+     * @returns {string} Label string resolved from the dish entry.
+     */
     getDishLabel(dishObject) {
         if (!dishObject || typeof dishObject !== "object") return "";
         return dishObject.name || dishObject.title || dishObject.label || dishObject.id || "";

--- a/js/core/wheel.js
+++ b/js/core/wheel.js
@@ -1,6 +1,9 @@
 /* File: wheel.js */
 /* global window */
 
+/** @typedef {import("../types.js").WheelLabelDescriptor} WheelLabelDescriptor */
+/** @typedef {import("../types.js").WheelSpinOptions} WheelSpinOptions */
+
 const DEFAULT_SPIN_DURATION_MS = 30000;
 const DEFAULT_REVOLUTIONS = 4;
 const POINTER_TAP_DURATION_MS = 70;
@@ -165,6 +168,11 @@ export class Wheel {
         this.draw();
     }
 
+    /**
+     * Applies the provided label entries to the wheel segments.
+     *
+     * @param {(WheelLabelDescriptor|string)[]} labelEntries - Raw label descriptors or plain strings for each segment.
+     */
     setLabels(labelEntries) {
         const normalized = Array.isArray(labelEntries) ? labelEntries : [];
         this.segmentLabels = normalized
@@ -203,6 +211,11 @@ export class Wheel {
         this.draw();
     }
 
+    /**
+     * Resets the wheel state ahead of a new spin operation.
+     *
+     * @param {WheelSpinOptions} [options] - Options controlling the reset behavior.
+     */
     resetForNewSpin({ randomizeStart = true } = {}) {
         this.cancelScheduledAnimation();
         this.isSpinning = false;
@@ -406,6 +419,11 @@ export class Wheel {
         return normalizedIndex;
     }
 
+    /**
+     * Initiates a spin animation targeting the provided segment index.
+     *
+     * @param {number} [requestedIndex] - Index of the segment to stop on; defaults to a random index when omitted.
+     */
     spin(requestedIndex) {
         if (this.isSpinning || !this.segmentLabels.length) {
             return;

--- a/js/types.d.js
+++ b/js/types.d.js
@@ -1,0 +1,102 @@
+/**
+ * Canonical domain type declarations for the Allergy Wheel application.
+ * These typedefs centralize the shapes shared across UI and core modules.
+ *
+ * @module Types
+ */
+
+/**
+ * Represents an avatar entry from the catalog rendered in the UI.
+ *
+ * @typedef {Object} AvatarDescriptor
+ * @property {string} key - Stable key used for referencing the descriptor in enumerations.
+ * @property {string} id - Unique identifier used for DOM dataset attributes and persisted state.
+ * @property {string} assetPath - Path or inline markup for the avatar asset rendered in the interface.
+ * @property {string} displayName - Human readable label presented alongside the avatar graphic.
+ */
+
+/**
+ * Describes a selectable allergen in the first card and throughout the game state.
+ *
+ * @typedef {Object} AllergenDescriptor
+ * @property {string} token - Canonical allergen token leveraged for normalization and filtering.
+ * @property {string} label - Display label shown to the player.
+ * @property {string} [emoji] - Optional emoji accompanying the allergen label in the UI.
+ */
+
+/**
+ * Defines the badge information rendered when an allergen is selected.
+ *
+ * @typedef {Object} AllergenBadgeEntry
+ * @property {string} label - Text displayed inside the badge element.
+ * @property {string} [emoji] - Optional emoji appended to the badge label.
+ */
+
+/**
+ * Represents a dish entry pulled from the dishes catalog.
+ *
+ * @typedef {Object} Dish
+ * @property {string} id - Unique identifier for the dish entry.
+ * @property {string} [emoji] - Emoji displayed when presenting the dish.
+ * @property {string} [name] - Primary dish name used in most UI contexts.
+ * @property {string} [title] - Optional alternate title for the dish.
+ * @property {string} [label] - Optional label fallback if name and title are unavailable.
+ * @property {string} [cuisine] - Cuisine or origin used for filtering and flag lookup.
+ * @property {string[]} [ingredients] - Ingredient list associated with the dish.
+ * @property {string} [narrative] - Narrative description displayed in the menu view.
+ */
+
+/**
+ * Normalization rule used by the NormalizationEngine to map ingredients to tokens.
+ *
+ * @typedef {Object} NormalizationRule
+ * @property {string} pattern - Regular expression pattern describing the ingredient match.
+ * @property {string} [flags] - Optional regex flags applied to the pattern.
+ * @property {string} token - Token emitted when the pattern matches an ingredient.
+ */
+
+/**
+ * Represents a cuisine and flag association sourced from the countries catalog.
+ *
+ * @typedef {Object} CountryDescriptor
+ * @property {string} cuisine - Cuisine name used as the lookup key.
+ * @property {string} [country] - Optional human readable country name associated with the cuisine.
+ * @property {string} [flag] - Emoji flag displayed next to the cuisine label.
+ */
+
+/**
+ * Represents an ingredient entry with an optional emoji and allergen mapping.
+ *
+ * @typedef {Object} IngredientDescriptor
+ * @property {string} name - Ingredient label stored in the catalog.
+ * @property {string} [emoji] - Emoji representing the ingredient.
+ * @property {string} [allergen] - Associated allergen token when applicable.
+ */
+
+/**
+ * Label information rendered on individual wheel segments.
+ *
+ * @typedef {Object} WheelLabelDescriptor
+ * @property {string} label - Text presented inside the wheel segment.
+ * @property {string} [emoji] - Optional emoji displayed next to the label.
+ */
+
+/**
+ * Options accepted when resetting the wheel prior to a new spin.
+ *
+ * @typedef {Object} WheelSpinOptions
+ * @property {boolean} [randomizeStart=true] - Indicates whether to randomize the wheel's starting angle.
+ */
+
+/**
+ * Aggregated game data dependencies loaded during bootstrap.
+ *
+ * @typedef {Object} GameData
+ * @property {AllergenDescriptor[]} allergensCatalog - Available allergen descriptors.
+ * @property {Dish[]} dishesCatalog - Catalog of dishes used for wheel segments and menu rendering.
+ * @property {NormalizationRule[]} normalizationRules - Normalization rules for mapping ingredients to allergens.
+ * @property {CountryDescriptor[]} [countriesCatalog] - Optional catalog mapping cuisines to country metadata.
+ * @property {IngredientDescriptor[]} ingredientsCatalog - Catalog providing ingredient emoji metadata.
+ */
+
+export {};

--- a/js/types.js
+++ b/js/types.js
@@ -1,0 +1,18 @@
+/**
+ * Re-exported typedefs for tooling compatibility.
+ * This module mirrors the declarations in {@link ./types.d.js} so that
+ * application modules can reference the shared shapes via JSDoc imports.
+ */
+
+/** @typedef {import('./types.d.js').AvatarDescriptor} AvatarDescriptor */
+/** @typedef {import('./types.d.js').AllergenDescriptor} AllergenDescriptor */
+/** @typedef {import('./types.d.js').AllergenBadgeEntry} AllergenBadgeEntry */
+/** @typedef {import('./types.d.js').Dish} Dish */
+/** @typedef {import('./types.d.js').NormalizationRule} NormalizationRule */
+/** @typedef {import('./types.d.js').CountryDescriptor} CountryDescriptor */
+/** @typedef {import('./types.d.js').IngredientDescriptor} IngredientDescriptor */
+/** @typedef {import('./types.d.js').WheelLabelDescriptor} WheelLabelDescriptor */
+/** @typedef {import('./types.d.js').WheelSpinOptions} WheelSpinOptions */
+/** @typedef {import('./types.d.js').GameData} GameData */
+
+export {};

--- a/js/ui/avatarRenderer.js
+++ b/js/ui/avatarRenderer.js
@@ -8,12 +8,20 @@ import {
     GlobalClassName
 } from "../constants.js";
 
+/** @typedef {import("../types.js").AvatarDescriptor} AvatarDescriptor */
+
 const HtmlTagName = Object.freeze({
     BUTTON: "button",
     IMG: "img",
     SPAN: "span"
 });
 
+/**
+ * Resolves the active avatar descriptor from the provided catalog and selected identifier.
+ *
+ * @param {{ avatarCatalog: AvatarDescriptor[], selectedAvatarId?: string }} options
+ * @returns {AvatarDescriptor | null}
+ */
 function resolveActiveAvatarDescriptor({
     avatarCatalog,
     selectedAvatarId
@@ -26,6 +34,17 @@ function resolveActiveAvatarDescriptor({
     return descriptorMap.get(selectedAvatarId) || defaultDescriptor;
 }
 
+/**
+ * Creates the avatar image element for the toggle button.
+ *
+ * @param {{
+ *     documentReference: Document,
+ *     avatarClassNameMap: typeof AvatarClassName,
+ *     avatarMenuText: typeof AvatarMenuText,
+ *     activeDescriptor: AvatarDescriptor | null
+ * }} options
+ * @returns {HTMLImageElement}
+ */
 function createToggleImageElement({
     documentReference,
     avatarClassNameMap,
@@ -45,6 +64,17 @@ function createToggleImageElement({
     return imageElement;
 }
 
+/**
+ * Creates the label element accompanying the avatar toggle.
+ *
+ * @param {{
+ *     documentReference: Document,
+ *     avatarClassNameMap: typeof AvatarClassName,
+ *     activeDescriptor: AvatarDescriptor | null,
+ *     globalClassName: typeof GlobalClassName
+ * }} options
+ * @returns {HTMLSpanElement}
+ */
 function createToggleLabelElement({
     documentReference,
     avatarClassNameMap,
@@ -71,6 +101,19 @@ function createVisuallyHiddenPrompt({ documentReference, globalClassName, avatar
     return hiddenPromptElement;
 }
 
+/**
+ * Populates the avatar toggle button with prompt text, image, and label.
+ *
+ * @param {{
+ *     toggleButtonElement: HTMLElement,
+ *     activeDescriptor: AvatarDescriptor | null,
+ *     documentReference: Document,
+ *     avatarClassNameMap: typeof AvatarClassName,
+ *     avatarMenuText: typeof AvatarMenuText,
+ *     globalClassName: typeof GlobalClassName
+ * }} options
+ * @returns {{ imageElement: HTMLImageElement, labelElement: HTMLSpanElement }}
+ */
 function populateToggleButton({
     toggleButtonElement,
     activeDescriptor,
@@ -105,6 +148,17 @@ function populateToggleButton({
     return { imageElement, labelElement };
 }
 
+/**
+ * Builds a menu option button for a single avatar descriptor.
+ *
+ * @param {{
+ *     documentReference: Document,
+ *     avatarClassNameMap: typeof AvatarClassName,
+ *     avatarMenuText: typeof AvatarMenuText,
+ *     avatarDescriptor: AvatarDescriptor
+ * }} options
+ * @returns {HTMLButtonElement}
+ */
 function createMenuOptionButton({
     documentReference,
     avatarClassNameMap,
@@ -139,6 +193,17 @@ function createMenuOptionButton({
     return optionButtonElement;
 }
 
+/**
+ * Renders the avatar selection menu options inside the provided container element.
+ *
+ * @param {{
+ *     menuContainerElement: HTMLElement,
+ *     avatarCatalog: AvatarDescriptor[],
+ *     documentReference: Document,
+ *     avatarClassNameMap: typeof AvatarClassName,
+ *     avatarMenuText: typeof AvatarMenuText
+ * }} options
+ */
 function populateMenuContainer({
     menuContainerElement,
     avatarCatalog,
@@ -158,6 +223,21 @@ function populateMenuContainer({
     }
 }
 
+/**
+ * Renders the avatar selection UI and returns references to the key elements.
+ *
+ * @param {{
+ *     toggleButtonElement?: HTMLElement | null,
+ *     menuContainerElement?: HTMLElement | null,
+ *     selectedAvatarId?: string,
+ *     avatarCatalog?: AvatarDescriptor[],
+ *     avatarClassNameMap?: typeof AvatarClassName,
+ *     avatarMenuText?: typeof AvatarMenuText,
+ *     globalClassName?: typeof GlobalClassName,
+ *     documentReference?: Document
+ * }} [options]
+ * @returns {{ imageElement: HTMLImageElement | null, labelElement: HTMLSpanElement | null }}
+ */
 export function renderAvatarSelector({
     toggleButtonElement,
     menuContainerElement,
@@ -201,6 +281,12 @@ export function renderAvatarSelector({
     return { imageElement, labelElement };
 }
 
+/**
+ * Builds a descriptor map keyed by avatar identifier for quick lookup.
+ *
+ * @param {AvatarDescriptor[]} [avatarCatalog=AvatarCatalog] - Catalog of available avatar descriptors.
+ * @returns {Map<string, AvatarDescriptor>} Map keyed by descriptor identifier.
+ */
 export function buildAvatarDescriptorMap(avatarCatalog = AvatarCatalog) {
     const descriptorMap = new Map();
     for (const descriptor of avatarCatalog) {

--- a/js/ui/firstCard.js
+++ b/js/ui/firstCard.js
@@ -1,6 +1,9 @@
 /* global document */
 import { AttributeBooleanValue, AttributeName, BrowserEventName, ControlElementId } from "../constants.js";
 
+/** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
+/** @typedef {import("../types.js").AllergenBadgeEntry} AllergenBadgeEntry */
+
 const ElementClassName = Object.freeze({
     CHIP: "chip",
     CHIP_SELECTED: "chip--selected",
@@ -38,6 +41,13 @@ export class AllergenCard {
 
     #onAllergenSelected;
 
+    /**
+     * @param {{
+     *     listContainerElement?: HTMLElement,
+     *     badgeContainerElement?: HTMLElement,
+     *     onAllergenSelected?: (descriptor: AllergenDescriptor) => void
+     * }} [dependencies]
+     */
     constructor({ listContainerElement, badgeContainerElement, onAllergenSelected } = {}) {
         this.#listContainerElement = listContainerElement || null;
         this.#badgeContainerElement = badgeContainerElement || null;
@@ -46,6 +56,11 @@ export class AllergenCard {
             : null;
     }
 
+    /**
+     * Renders allergen chips into the configured list container.
+     *
+     * @param {AllergenDescriptor[]} allergenList - Collection of allergens available for selection.
+     */
     renderAllergens(allergenList) {
         if (!this.#listContainerElement) {
             return;
@@ -116,6 +131,11 @@ export class AllergenCard {
         }
     }
 
+    /**
+     * Updates the badge container to reflect the selected allergen(s).
+     *
+     * @param {(AllergenBadgeEntry|string)[]} allergenEntries - Badge descriptors or string labels to render.
+     */
     updateBadges(allergenEntries) {
         if (!this.#badgeContainerElement) {
             return;
@@ -191,6 +211,11 @@ export class AllergenCard {
         }
     }
 
+    /**
+     * Emits the selected allergen descriptor through the configured callback.
+     *
+     * @param {AllergenDescriptor} allergenDescriptor - Descriptor representing the chosen allergen.
+     */
     #handleAllergenSelection(allergenDescriptor) {
         if (typeof this.#onAllergenSelected !== ValueType.FUNCTION) {
             return;

--- a/js/ui/lastCard.js
+++ b/js/ui/lastCard.js
@@ -7,6 +7,9 @@ import {
     AvatarId
 } from "../constants.js";
 
+/** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
+/** @typedef {import("../types.js").Dish} Dish */
+
 const ElementTagName = Object.freeze({
     SPAN: "span",
     BUTTON: "button"
@@ -116,6 +119,25 @@ export class ResultCard {
 
     #selectedAvatarId;
 
+    /**
+     * @param {{
+     *     documentReference?: Document,
+     *     revealSectionElement?: HTMLElement | null,
+     *     dishTitleElement?: HTMLElement | null,
+     *     dishCuisineElement?: HTMLElement | null,
+     *     resultBannerElement?: HTMLElement | null,
+     *     resultTextElement?: HTMLElement | null,
+     *     ingredientsContainerElement?: HTMLElement | null,
+     *     faceSvgElement?: SVGElement | HTMLElement | null,
+     *     gameOverSectionElement?: HTMLElement | null,
+     *     normalizationEngine?: import("../utils/utils.js").NormalizationEngine | null,
+     *     allergensCatalog?: AllergenDescriptor[],
+     *     cuisineToFlagMap?: Map<string, string> | Iterable<[string, string]>,
+     *     ingredientEmojiByName?: Map<string, string> | Iterable<[string, string]>,
+     *     avatarMap?: Map<string, string> | Iterable<[string, string]>,
+     *     selectedAvatarId?: string
+     * }} [dependencies]
+     */
     constructor({
         documentReference = document,
         revealSectionElement,
@@ -156,6 +178,16 @@ export class ResultCard {
         this.updateAvatarSelection(selectedAvatarId);
     }
 
+    /**
+     * Refreshes cached dependencies when new catalog data is supplied.
+     *
+     * @param {{
+     *     normalizationEngine?: import("../utils/utils.js").NormalizationEngine | null,
+     *     allergensCatalog?: AllergenDescriptor[],
+     *     cuisineToFlagMap?: Map<string, string> | Iterable<[string, string]>,
+     *     ingredientEmojiByName?: Map<string, string> | Iterable<[string, string]>
+     * }} [dependencies]
+     */
     updateDataDependencies({
         normalizationEngine,
         allergensCatalog,
@@ -177,6 +209,12 @@ export class ResultCard {
         }
     }
 
+    /**
+     * Updates the active avatar resource and re-renders the SVG when possible.
+     *
+     * @param {string | null | undefined} avatarIdentifierCandidate - Candidate avatar identifier selected by the player.
+     * @returns {{ selectedAvatarId: string, hasRenderableAvatar: boolean }} Result of the update operation.
+     */
     updateAvatarSelection(avatarIdentifierCandidate) {
         const normalizedCandidate = typeof avatarIdentifierCandidate === "string"
             ? avatarIdentifierCandidate.trim()
@@ -209,6 +247,16 @@ export class ResultCard {
         };
     }
 
+    /**
+     * Populates the reveal card UI with the provided dish details.
+     *
+     * @param {{
+     *     dish: Dish | null,
+     *     selectedAllergenToken: string | null,
+     *     selectedAllergenLabel: string
+     * }} options
+     * @returns {{ hasTriggeringIngredient: boolean }} Indicates whether the dish contains the selected allergen.
+     */
     populateRevealCard({
         dish,
         selectedAllergenToken,
@@ -412,6 +460,12 @@ export class ResultCard {
         return false;
     }
 
+    /**
+     * Constructs a lookup map from allergen token to emoji for quick ingredient decoration.
+     *
+     * @param {AllergenDescriptor[]} [allergensCatalog] - Catalog entries supplying allergen emojis.
+     * @returns {Map<string, string>} Map keyed by allergen token with emoji values.
+     */
     #buildEmojiByTokenMap(allergensCatalog) {
         const emojiMap = new Map();
         for (const allergenRecord of allergensCatalog || []) {

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -1,5 +1,8 @@
 import { ScreenName } from "../constants.js";
 
+/** @typedef {import("../types.js").Dish} Dish */
+/** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
+
 const TextContent = Object.freeze({
     EMPTY: ""
 });
@@ -89,6 +92,9 @@ export class MenuView {
 
     #selectedAllergenLabel = TextContent.EMPTY;
 
+    /**
+     * @param {{ documentReference?: Document, menuTableBodyElement?: HTMLElement | null }} [dependencies]
+     */
     constructor({
         documentReference = document,
         menuTableBodyElement
@@ -97,6 +103,17 @@ export class MenuView {
         this.#menuTableBodyElement = menuTableBodyElement || null;
     }
 
+    /**
+     * Updates the menu presenter caches with the latest catalog information.
+     *
+     * @param {{
+     *     dishesCatalog?: Dish[],
+     *     normalizationEngine?: import("../utils/utils.js").NormalizationEngine | null,
+     *     ingredientEmojiByName?: Map<string, string> | Iterable<[string, string]>,
+     *     cuisineToFlagMap?: Map<string, string> | Iterable<[string, string]>,
+     *     allergensCatalog?: AllergenDescriptor[]
+     * }} [dependencies]
+     */
     updateDataDependencies({
         dishesCatalog,
         normalizationEngine,
@@ -133,6 +150,11 @@ export class MenuView {
         this.#emitFilterOptionsChange();
     }
 
+    /**
+     * Reflects the selected allergen token and label and re-renders the menu view.
+     *
+     * @param {{ token?: string | null, label?: string }} [selection]
+     */
     updateSelectedAllergen({ token, label } = {}) {
         this.#selectedAllergenToken = token || null;
         this.#selectedAllergenLabel = label || TextContent.EMPTY;
@@ -192,6 +214,7 @@ export class MenuView {
 
         this.#menuTableBodyElement.textContent = TextContent.EMPTY;
 
+        /** @type {Dish[]} */
         const dishesToRender = this.#filterDishes(this.#dishesCatalog);
 
         if (dishesToRender.length === 0) {
@@ -302,6 +325,12 @@ export class MenuView {
         return cellElement;
     }
 
+    /**
+     * Applies the active cuisine and ingredient filters to the provided dish catalog.
+     *
+     * @param {Dish[]} dishCatalog - Catalog of dishes to filter.
+     * @returns {Dish[]} Filtered list of dishes respecting the active selections.
+     */
     #filterDishes(dishCatalog) {
         const sourceCatalog = Array.isArray(dishCatalog) ? dishCatalog : [];
         const filteredDishes = [];
@@ -513,6 +542,12 @@ export class MenuView {
         return this.#cuisineToFlagMap.get(normalizedKey) || TextContent.EMPTY;
     }
 
+    /**
+     * Builds a mapping from allergen token to emoji for quick ingredient decoration.
+     *
+     * @param {AllergenDescriptor[]} [allergensCatalog] - Catalog entries containing allergen emojis.
+     * @returns {Map<string, string>} Map keyed by allergen token with emoji values.
+     */
     #buildEmojiByTokenMap(allergensCatalog) {
         const emojiMap = new Map();
         for (const allergenRecord of allergensCatalog) {

--- a/js/utils/utils.js
+++ b/js/utils/utils.js
@@ -1,5 +1,7 @@
 /* global window */
 
+/** @typedef {import("../types.js").NormalizationRule} NormalizationRule */
+
 export async function loadJson(pathString) {
     const httpResponse = await fetch(pathString, { cache: "no-store" });
     if (!httpResponse.ok) throw new Error(`failed to load ${pathString}`);
@@ -7,6 +9,9 @@ export async function loadJson(pathString) {
 }
 
 export class NormalizationEngine {
+    /**
+     * @param {NormalizationRule[]} ruleDescriptors - Descriptors used to compile normalization regular expressions.
+     */
     constructor(ruleDescriptors) {
         this.compiledRules = [];
         if (Array.isArray(ruleDescriptors)) {
@@ -23,6 +28,12 @@ export class NormalizationEngine {
         }
     }
 
+    /**
+     * Determines the set of allergen tokens triggered by a single ingredient string.
+     *
+     * @param {string} ingredientText - Ingredient text to evaluate against the compiled rules.
+     * @returns {Set<string>} Set of allergen tokens detected within the ingredient text.
+     */
     tokensForIngredient(ingredientText) {
         const foundTokens = new Set();
         const candidateText = String(ingredientText || "");
@@ -35,6 +46,12 @@ export class NormalizationEngine {
         return foundTokens;
     }
 
+    /**
+     * Aggregates allergen tokens detected across a list of ingredient strings.
+     *
+     * @param {string[]} ingredientArray - Collection of ingredient text entries for a dish.
+     * @returns {Set<string>} Union of allergen tokens produced for the provided ingredients.
+     */
     tokensForDishIngredients(ingredientArray) {
         const union = new Set();
         for (const singleIngredient of ingredientArray || []) {


### PR DESCRIPTION
## Summary
- add shared type definitions for avatars, allergens, dishes, and other domain data
- update core logic to reference the canonical typedefs in documentation comments
- refresh UI presenters to import the shared typedefs for consistent tooling hints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1a27b9da083278ffa20b97c176677