### PR TITLE
Add browser compatibility data to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ An interactive allergy wheel game rendered in the browser. The project now inclu
 
 | Browser | Minimum version | Release date | Market share after release |
 | --- | --- | --- | --- |
-| Chrome | 84 | July 14, 2020[^chrome-84-release] | 26.07% (Aug 2020 global usage)[^caniuse-202008] |
-| Edge | 84 | July 16, 2020[^edge-84-release] | 2.08% (Aug 2020 global usage)[^caniuse-202008] |
-| Firefox | 90 | July 13, 2021[^firefox-90-release] | 1.01% (Aug 2021 global usage)[^caniuse-202108] |
-| Safari | 14 | September 16, 2020[^safari-14-release] | 1.50% (Oct 2020 global usage)[^caniuse-202010] |
+| Chrome | 84 | July 14, 2020[^chrome-84-release] | 26.95% (Aug 2020 cumulative global usage)[^caniuse-202008] |
+| Edge | 84 | July 16, 2020[^edge-84-release] | 2.25% (Aug 2020 cumulative global usage)[^caniuse-202008] |
+| Firefox | 90 | July 13, 2021[^firefox-90-release] | 2.51% (Aug 2021 cumulative global usage)[^caniuse-202108] |
+| Safari | 14 | September 16, 2020[^safari-14-release] | 1.50% (Oct 2020 cumulative global usage)[^caniuse-202010] |
 
 [^chrome-84-release]: Stable Channel Update for Desktop (Chrome 84), Chrome Releases Blog, July 14 2020. <https://chromereleases.googleblog.com/2020/07/stable-channel-update-for-desktop.html>
 [^edge-84-release]: Microsoft Edge Stable Channel release notes, version 84, Microsoft Learn. <https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel>
 [^firefox-90-release]: Firefox 90.0 release notes, Mozilla, July 13 2021. <https://www.mozilla.org/en-US/firefox/90.0/releasenotes/>
 [^safari-14-release]: About Safari 14 updates, Apple Support, September 16 2020. <https://support.apple.com/en-us/HT211956>
-[^caniuse-202008]: Can I Use global usage table (StatCounter), August 2020 dataset for Chrome 84 and Edge 84. <https://github.com/Fyrd/caniuse/blob/48d1b73113f878a55aaccce25f8c52252720ef55/region-usage-json/alt-ww.json>
-[^caniuse-202010]: Can I Use global usage table (StatCounter), October 2020 dataset for Safari 14. <https://github.com/Fyrd/caniuse/blob/f65f7d5a78ae6e00d1dcbb25f4108a779b0f886d/region-usage-json/alt-ww.json>
-[^caniuse-202108]: Can I Use global usage table (StatCounter), August 2021 dataset for Firefox 90. <https://github.com/Fyrd/caniuse/blob/7be48174f480d080126d25edbd67573494959e6a/region-usage-json/alt-ww.json>
+[^caniuse-202008]: Sum of StatCounter global usage for Chrome 84 and later (26.95%) and Edge 84 and later (2.25%) using the August 2020 `alt-ww.json` dataset. <https://github.com/Fyrd/caniuse/blob/48d1b73113f878a55aaccce25f8c52252720ef55/region-usage-json/alt-ww.json>
+[^caniuse-202010]: Sum of StatCounter global usage for Safari 14 and later (1.50%) using the October 2020 `alt-ww.json` dataset. <https://github.com/Fyrd/caniuse/blob/f65f7d5a78ae6e00d1dcbb25f4108a779b0f886d/region-usage-json/alt-ww.json>
+[^caniuse-202108]: Sum of StatCounter global usage for Firefox 90 and later (2.51%) using the August 2021 `alt-ww.json` dataset. <https://github.com/Fyrd/caniuse/blob/7be48174f480d080126d25edbd67573494959e6a/region-usage-json/alt-ww.json>
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- add a Browser compatibility section near the top of the README
- document minimum supported browser versions with release dates and post-release market share
- reference the release notes and Can I Use (StatCounter) datasets so future updates remain traceable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1aadd08a08327bbef8b4feac2c9a3