### PR TITLE
Align menu mobile breakpoint with header

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1029,7 +1029,7 @@ body[data-screen="menu"] #screen-menu { display: block }
     line-height: 1.5;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 767px) {
     #screen-menu { padding: 18px; }
     .menu-card { padding: 18px; }
     .menu-table-wrapper { border-radius: 18px; }


### PR DESCRIPTION
## Plan
- align the menu mobile breakpoint with the header breakpoint
- verify the menu layout responds correctly at 750px viewport widths

## Summary
- updated the menu small-screen media query to use a max-width of 767px so it matches the header breakpoint and keeps the vertical layout active throughout the mobile range

## Testing
- npm test
- Manual: inspected menu layout at a 750px viewport

------
https://chatgpt.com/codex/tasks/task_e_68d1c6fc3bac8327910a6dd428cc8460