### PR TITLE
Add responsive menu column labels

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -204,6 +204,61 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         font-size: 16px;
     }
 
+    .menu-table thead {
+        display: none;
+    }
+
+    .menu-table tbody {
+        display: block;
+        width: 100%;
+    }
+
+    .menu-table tbody tr {
+        display: block;
+    }
+
+    .menu-table tbody tr + tr {
+        margin-top: 16px;
+    }
+
+    .menu-table tbody td {
+        display: grid;
+        grid-template-columns: minmax(0, auto) 1fr;
+        column-gap: 12px;
+        row-gap: 8px;
+        align-items: flex-start;
+        padding: clamp(14px, 4vw, 20px);
+        border-bottom: none;
+    }
+
+    .menu-table tbody td + td {
+        border-top: 2px solid #ffd6e3;
+    }
+
+    .menu-table tbody td > .menu-cell__label {
+        display: inline-flex;
+        align-items: center;
+        font-weight: 800;
+        font-size: clamp(12px, 3.2vw, 13px);
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        grid-column: 1;
+        line-height: 1.2;
+        white-space: nowrap;
+    }
+
+    .menu-table tbody td > .menu-cell__label::after {
+        content: " |";
+        margin-left: 8px;
+        color: currentColor;
+        font-weight: 700;
+    }
+
+    .menu-table tbody td > :not(.menu-cell__label) {
+        grid-column: 2;
+    }
+
     @media (max-width: 360px) {
         header {
             column-gap: 8px;
@@ -995,6 +1050,10 @@ body[data-screen="menu"] #screen-menu { display: block }
 
 .menu-table tbody tr:last-child td { border-bottom: none; }
 
+.menu-cell__label {
+    display: none;
+}
+
 .menu-dish-heading {
     display: flex;
     align-items: center;
@@ -1033,8 +1092,11 @@ body[data-screen="menu"] #screen-menu { display: block }
     #screen-menu { padding: 18px; }
     .menu-card { padding: 18px; }
     .menu-table-wrapper { border-radius: 18px; }
-    .menu-table thead { position: sticky; top: 0; z-index: 1; }
-    .menu-table tbody td { display: block; }
+    .menu-table thead { display: none; }
+    .menu-table tbody td {
+        display: grid;
+        grid-template-columns: minmax(0, auto) 1fr;
+    }
     .menu-header-cell { align-items: flex-start; }
     .menu-header-toggle { width: 100%; justify-content: space-between; }
     .menu-filter-panel {

--- a/js/constants.js
+++ b/js/constants.js
@@ -239,6 +239,18 @@ export const MenuFilterText = Object.freeze({
     SELECT_ALL_LABEL: "Show all"
 });
 
+const MenuColumnLabelDishText = "Dish";
+const MenuColumnLabelIngredientsText = "Ingredients";
+const MenuColumnLabelCuisineText = "Cuisine";
+const MenuColumnLabelStoryText = "Story";
+
+export const MenuColumnLabel = Object.freeze({
+    DISH: MenuColumnLabelDishText,
+    INGREDIENTS: MenuColumnLabelIngredientsText,
+    CUISINE: MenuColumnLabelCuisineText,
+    STORY: MenuColumnLabelStoryText
+});
+
 export const DocumentElementId = Object.freeze({
     LOADING: "loading",
     LOAD_ERROR: "load-error",
@@ -259,7 +271,8 @@ export const AttributeName = Object.freeze({
     DATA_SCREEN: "data-screen",
     DATA_COUNT: "data-count",
     DATA_BLOCKED: "data-blocked",
-    DATA_WHEEL_CONTROL_MODE: "data-wheel-control-mode"
+    DATA_WHEEL_CONTROL_MODE: "data-wheel-control-mode",
+    DATA_COLUMN_LABEL: "data-column-label"
 });
 
 export const AttributeBooleanValue = Object.freeze({

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -1,4 +1,4 @@
-import { ScreenName } from "../constants.js";
+import { ScreenName, MenuColumnLabel, AttributeName } from "../constants.js";
 
 /** @typedef {import("../types.js").Dish} Dish */
 /** @typedef {import("../types.js").AllergenDescriptor} AllergenDescriptor */
@@ -21,6 +21,7 @@ const ClassName = Object.freeze({
     CELL_INGREDIENTS: "menu-cell menu-cell--ingredients",
     CELL_CUISINE: "menu-cell menu-cell--cuisine",
     CELL_NARRATIVE: "menu-cell menu-cell--narrative",
+    CELL_LABEL: "menu-cell__label",
     DISH_HEADING: "menu-dish-heading",
     DISH_TITLE: "menu-dish-title",
     INGREDIENTS_CONTAINER: "ingredients menu-ingredients",
@@ -249,6 +250,7 @@ export class MenuView {
     #createDishCell(dishRecord) {
         const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
         cellElement.className = ClassName.CELL_DISH;
+        this.#decorateCellWithColumnLabel(cellElement, MenuColumnLabel.DISH);
 
         const headingElement = this.#documentReference.createElement(HtmlTagName.DIV);
         headingElement.className = ClassName.DISH_HEADING;
@@ -274,6 +276,7 @@ export class MenuView {
     #createIngredientsCell(dishRecord) {
         const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
         cellElement.className = ClassName.CELL_INGREDIENTS;
+        this.#decorateCellWithColumnLabel(cellElement, MenuColumnLabel.INGREDIENTS);
 
         const ingredientsContainer = this.#documentReference.createElement(HtmlTagName.DIV);
         ingredientsContainer.className = ClassName.INGREDIENTS_CONTAINER;
@@ -291,6 +294,7 @@ export class MenuView {
     #createCuisineCell(dishRecord) {
         const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
         cellElement.className = ClassName.CELL_CUISINE;
+        this.#decorateCellWithColumnLabel(cellElement, MenuColumnLabel.CUISINE);
 
         const badgeElement = this.#documentReference.createElement(HtmlTagName.SPAN);
         badgeElement.className = ClassName.CUISINE_BADGE;
@@ -316,6 +320,7 @@ export class MenuView {
     #createNarrativeCell(dishRecord) {
         const cellElement = this.#documentReference.createElement(HtmlTagName.TD);
         cellElement.className = ClassName.CELL_NARRATIVE;
+        this.#decorateCellWithColumnLabel(cellElement, MenuColumnLabel.STORY);
 
         const paragraphElement = this.#documentReference.createElement(HtmlTagName.P);
         paragraphElement.className = ClassName.NARRATIVE;
@@ -323,6 +328,16 @@ export class MenuView {
 
         cellElement.appendChild(paragraphElement);
         return cellElement;
+    }
+
+    #decorateCellWithColumnLabel(cellElement, columnLabelText) {
+        const labelText = typeof columnLabelText === "string" ? columnLabelText : TextContent.EMPTY;
+        cellElement.setAttribute(AttributeName.DATA_COLUMN_LABEL, labelText);
+
+        const labelSpan = this.#documentReference.createElement(HtmlTagName.SPAN);
+        labelSpan.className = ClassName.CELL_LABEL;
+        labelSpan.textContent = labelText;
+        cellElement.appendChild(labelSpan);
     }
 
     /**

--- a/tests/integration/menuFilters.integration.test.js
+++ b/tests/integration/menuFilters.integration.test.js
@@ -1,6 +1,6 @@
 import { MenuView } from "../../js/ui/menu.js";
 import { MenuFilterController } from "../../js/ui/menuFilters.js";
-import { MenuElementId } from "../../js/constants.js";
+import { MenuElementId, MenuColumnLabel } from "../../js/constants.js";
 import { NormalizationEngine } from "../../js/utils/utils.js";
 
 const HtmlTagName = Object.freeze({
@@ -115,7 +115,7 @@ function buildMenuTableMarkup() {
     <${HtmlTagName.TABLE}>
       <${HtmlTagName.THEAD}>
         <${HtmlTagName.TR}>
-          <${HtmlTagName.TH}>Dish</${HtmlTagName.TH}>
+          <${HtmlTagName.TH}>${MenuColumnLabel.DISH}</${HtmlTagName.TH}>
           <${HtmlTagName.TH}>
             <${HtmlTagName.DIV} class="${CssClassName.HEADER_CELL}">
               <${HtmlTagName.BUTTON}
@@ -125,7 +125,7 @@ function buildMenuTableMarkup() {
                 aria-haspopup="true"
                 aria-expanded="false"
                 type="button"
-              >Ingredients</${HtmlTagName.BUTTON}>
+              >${MenuColumnLabel.INGREDIENTS}</${HtmlTagName.BUTTON}>
               <${HtmlTagName.DIV}
                 id="${MenuElementId.INGREDIENT_FILTER_PANEL}"
                 class="${CssClassName.FILTER_PANEL}"
@@ -154,7 +154,7 @@ function buildMenuTableMarkup() {
                 aria-haspopup="true"
                 aria-expanded="false"
                 type="button"
-              >Cuisine</${HtmlTagName.BUTTON}>
+              >${MenuColumnLabel.CUISINE}</${HtmlTagName.BUTTON}>
               <${HtmlTagName.DIV}
                 id="${MenuElementId.CUISINE_FILTER_PANEL}"
                 class="${CssClassName.FILTER_PANEL}"
@@ -174,7 +174,7 @@ function buildMenuTableMarkup() {
               </${HtmlTagName.DIV}>
             </${HtmlTagName.DIV}>
           </${HtmlTagName.TH}>
-          <${HtmlTagName.TH}>Story</${HtmlTagName.TH}>
+          <${HtmlTagName.TH}>${MenuColumnLabel.STORY}</${HtmlTagName.TH}>
         </${HtmlTagName.TR}>
       </${HtmlTagName.THEAD}>
       <${HtmlTagName.TBODY} id="${MenuElementId.TABLE_BODY}"></${HtmlTagName.TBODY}>

--- a/tests/integration/navigationMenu.integration.test.js
+++ b/tests/integration/navigationMenu.integration.test.js
@@ -6,7 +6,8 @@ import {
   AttributeName,
   AttributeBooleanValue,
   ScreenName,
-  MenuElementId
+  MenuElementId,
+  MenuColumnLabel
 } from "../../js/constants.js";
 import { NormalizationEngine } from "../../js/utils/utils.js";
 
@@ -14,6 +15,17 @@ const HtmlTagName = Object.freeze({
   BUTTON: "button",
   TABLE: "table",
   TBODY: "tbody"
+});
+
+const MenuCellSelector = Object.freeze({
+  DISH: ".menu-cell--dish",
+  INGREDIENTS: ".menu-cell--ingredients",
+  CUISINE: ".menu-cell--cuisine",
+  STORY: ".menu-cell--narrative"
+});
+
+const MenuCellClassName = Object.freeze({
+  LABEL: "menu-cell__label"
 });
 
 const NavigationScenarioDescription = Object.freeze({
@@ -30,6 +42,13 @@ const NavigationActiveStateScenario = Object.freeze({
 const MenuRenderingScenarioDescription = Object.freeze({
   NO_SELECTION: "renders dishes without highlights when no allergen is selected",
   WITH_SELECTION: "highlights allergen ingredients when an allergen is selected"
+});
+
+const MenuColumnLabelScenarioDescription = Object.freeze({
+  DISH: "injects the dish column label before the dish content",
+  INGREDIENTS: "injects the ingredients column label before the ingredient chips",
+  CUISINE: "injects the cuisine column label before the cuisine badge",
+  STORY: "injects the story column label before the narrative paragraph"
 });
 
 const NavigationClickScenarios = Object.freeze([
@@ -76,6 +95,29 @@ const MenuRenderingScenarios = Object.freeze([
     description: MenuRenderingScenarioDescription.WITH_SELECTION,
     selectedAllergen: { token: "peanut", label: "Peanut" },
     expectedHighlightedIngredients: ["Peanuts"]
+  })
+]);
+
+const MenuColumnLabelScenarios = Object.freeze([
+  Object.freeze({
+    description: MenuColumnLabelScenarioDescription.DISH,
+    cellSelector: MenuCellSelector.DISH,
+    expectedLabel: MenuColumnLabel.DISH
+  }),
+  Object.freeze({
+    description: MenuColumnLabelScenarioDescription.INGREDIENTS,
+    cellSelector: MenuCellSelector.INGREDIENTS,
+    expectedLabel: MenuColumnLabel.INGREDIENTS
+  }),
+  Object.freeze({
+    description: MenuColumnLabelScenarioDescription.CUISINE,
+    cellSelector: MenuCellSelector.CUISINE,
+    expectedLabel: MenuColumnLabel.CUISINE
+  }),
+  Object.freeze({
+    description: MenuColumnLabelScenarioDescription.STORY,
+    cellSelector: MenuCellSelector.STORY,
+    expectedLabel: MenuColumnLabel.STORY
   })
 ]);
 
@@ -228,5 +270,53 @@ describe("MenuView", () => {
         )
       ).toBe(true);
     }
+  });
+
+  test.each(MenuColumnLabelScenarios)("%s", ({ cellSelector, expectedLabel }) => {
+    document.body.innerHTML = `
+      <${HtmlTagName.TABLE}>
+        <${HtmlTagName.TBODY} id="${MenuElementId.TABLE_BODY}"></${HtmlTagName.TBODY}>
+      </${HtmlTagName.TABLE}>
+    `;
+
+    const menuTableBodyElement = document.getElementById(MenuElementId.TABLE_BODY);
+    const menuView = new MenuView({
+      documentReference: document,
+      menuTableBodyElement
+    });
+
+    const normalizationEngine = new NormalizationEngine(NormalizationRules);
+
+    menuView.updateDataDependencies({
+      dishesCatalog: SampleDishes,
+      normalizationEngine,
+      ingredientEmojiByName: new Map(IngredientEmojiEntries),
+      cuisineToFlagMap: new Map(CuisineFlagEntries),
+      allergensCatalog: AllergenCatalog
+    });
+
+    menuView.updateSelectedAllergen({});
+
+    const firstRowElement = menuTableBodyElement.querySelector("tr");
+    expect(firstRowElement).not.toBeNull();
+
+    if (!firstRowElement) {
+      throw new Error("Menu row not rendered");
+    }
+
+    const targetCellElement = firstRowElement.querySelector(cellSelector);
+    expect(targetCellElement).not.toBeNull();
+
+    if (!targetCellElement) {
+      throw new Error(`Cell for selector ${cellSelector} not found`);
+    }
+
+    const labelElements = targetCellElement.querySelectorAll(`.${MenuCellClassName.LABEL}`);
+    expect(labelElements).toHaveLength(1);
+
+    const [labelElement] = labelElements;
+    expect(labelElement.textContent).toBe(expectedLabel);
+    expect(targetCellElement.getAttribute(AttributeName.DATA_COLUMN_LABEL)).toBe(expectedLabel);
+    expect(labelElement).toBe(targetCellElement.firstElementChild);
   });
 });


### PR DESCRIPTION
## Summary
- add menu column label constants and expose a data attribute name for table cells
- update MenuView to prepend labeled spans and data attributes for each column
- extend small-screen menu styling to surface the labels and adjust layout
- refresh integration tests to cover column labels and consume centralized strings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1cdf1be94832782312db6e77ef367