### PR TITLE
Restore table layout on small screens

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -208,15 +208,6 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         display: none;
     }
 
-    .menu-table tbody {
-        display: block;
-        width: 100%;
-    }
-
-    .menu-table tbody tr {
-        display: block;
-    }
-
     .menu-table tbody tr + tr {
         margin-top: 16px;
     }


### PR DESCRIPTION
## Plan
- Remove the block display overrides applied to the menu table elements on small screens.
- Rely on the existing cell grid styling while running the Jest suite to confirm no regressions.

## Summary
- Removed the mobile-only `display` and `width` overrides from the menu table so it can keep intrinsic column sizing and zebra striping.
- Retained the grid-based cell styling for the label and value pair presentation.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1dda62a308327a9cb632ae405ec58