### PR TITLE
Add responsive menu row headers for mobile view

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -208,6 +208,7 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         display: block;
         width: 100%;
         background: #fffaf1;
+        border-spacing: 0;
         box-sizing: border-box;
     }
 
@@ -221,62 +222,50 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         background: inherit;
     }
 
-    .menu-table tbody tr {
-        display: block;
-        width: 100%;
+    .menu-row--mobile-header {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 12px;
+        align-items: center;
+        padding: 12px 16px;
+        background: #ffdfe9;
+        border-bottom: 2px solid #ffd6e3;
         box-sizing: border-box;
-    }
-
-    .menu-table tbody tr + tr {
         margin-top: 16px;
     }
 
-    .menu-table tbody td {
-        display: grid;
-        grid-template-columns: max-content minmax(0, 1fr);
-        column-gap: 12px;
-        row-gap: 8px;
-        align-items: flex-start;
-        padding: clamp(14px, 4vw, 20px);
-        border-bottom: none;
-        width: 100%;
-        box-sizing: border-box;
+    .menu-row--mobile-header:first-child {
+        margin-top: 0;
     }
 
-    .menu-table tbody td + td {
-        border-top: 2px solid #ffd6e3;
-    }
-
-    .menu-table tbody td > .menu-cell__label {
-        display: inline-flex;
-        align-items: center;
+    .menu-row--mobile-header .menu-mobile-header-cell {
+        display: block;
+        margin: 0;
+        padding: 0;
         font-weight: 800;
         font-size: clamp(12px, 3.2vw, 13px);
         text-transform: uppercase;
         letter-spacing: 0.08em;
         color: var(--muted);
-        grid-column: 1;
-        line-height: 1.2;
-        white-space: nowrap;
-        position: relative;
-        padding-right: 12px;
-        margin-right: 12px;
+        text-align: left;
     }
 
-    .menu-table tbody td > .menu-cell__label::after {
-        content: "";
-        position: absolute;
-        top: 50%;
-        right: 0;
-        transform: translateY(-50%);
-        width: 2px;
-        height: 1.1em;
-        background: currentColor;
-        border-radius: 1px;
+    .menu-row--data {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
     }
 
-    .menu-table tbody td > :not(.menu-cell__label) {
-        grid-column: 2;
+    .menu-row--data td {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        padding: clamp(14px, 4vw, 20px);
+        border-bottom: none;
+    }
+
+    .menu-row--data td + td {
+        border-top: 2px solid #ffd6e3;
     }
 
     @media (max-width: 360px) {
@@ -1059,8 +1048,12 @@ body[data-screen="menu"] #screen-menu { display: block }
     padding: 32px 16px;
 }
 
-.menu-table tbody tr:nth-child(odd) { background: #fff; }
-.menu-table tbody tr:nth-child(even) { background: #fff5f9; }
+@media (min-width: 768px) {
+    .menu-row--mobile-header { display: none; }
+}
+
+.menu-table tbody tr.menu-row--data:nth-of-type(4n + 2) { background: #fff; }
+.menu-table tbody tr.menu-row--data:nth-of-type(4n) { background: #fff5f9; }
 
 .menu-table tbody td {
     padding: clamp(14px, 2.4vw, 22px);
@@ -1113,10 +1106,6 @@ body[data-screen="menu"] #screen-menu { display: block }
     .menu-card { padding: 18px; }
     .menu-table-wrapper { border-radius: 18px; }
     .menu-table thead { display: none; }
-    .menu-table tbody td {
-        display: grid;
-        grid-template-columns: minmax(0, auto) 1fr;
-    }
     .menu-header-cell { align-items: flex-start; }
     .menu-header-toggle { width: 100%; justify-content: space-between; }
     .menu-filter-panel {

--- a/js/ui/menu.js
+++ b/js/ui/menu.js
@@ -10,13 +10,24 @@ const TextContent = Object.freeze({
 const HtmlTagName = Object.freeze({
     TR: "tr",
     TD: "td",
+    TH: "th",
     DIV: "div",
     SPAN: "span",
     P: "p"
 });
 
+const HtmlAttributeName = Object.freeze({
+    SCOPE: "scope"
+});
+
+const TableHeaderScopeValue = Object.freeze({
+    COLUMN: "col"
+});
+
 const ClassName = Object.freeze({
-    ROW: "menu-row",
+    ROW_DATA: "menu-row menu-row--data",
+    ROW_MOBILE_HEADER: "menu-row menu-row--mobile-header",
+    MOBILE_HEADER_CELL: "menu-mobile-header-cell",
     CELL_DISH: "menu-cell menu-cell--dish",
     CELL_INGREDIENTS: "menu-cell menu-cell--ingredients",
     CELL_CUISINE: "menu-cell menu-cell--cuisine",
@@ -224,20 +235,21 @@ export class MenuView {
             return;
         }
 
+        const menuBodyFragment = this.#documentReference.createDocumentFragment();
+
         for (const dishRecord of dishesToRender) {
             if (!dishRecord) {
                 continue;
             }
-            const rowElement = this.#documentReference.createElement(HtmlTagName.TR);
-            rowElement.className = ClassName.ROW;
 
-            rowElement.appendChild(this.#createDishCell(dishRecord));
-            rowElement.appendChild(this.#createIngredientsCell(dishRecord));
-            rowElement.appendChild(this.#createCuisineCell(dishRecord));
-            rowElement.appendChild(this.#createNarrativeCell(dishRecord));
+            const mobileHeaderRow = this.#createResponsiveHeaderRow();
+            const dataRowElement = this.#createMenuDataRow(dishRecord);
 
-            this.#menuTableBodyElement.appendChild(rowElement);
+            menuBodyFragment.appendChild(mobileHeaderRow);
+            menuBodyFragment.appendChild(dataRowElement);
         }
+
+        this.#menuTableBodyElement.appendChild(menuBodyFragment);
     }
 
     getSelectedAllergen() {
@@ -245,6 +257,45 @@ export class MenuView {
             token: this.#selectedAllergenToken,
             label: this.#selectedAllergenLabel
         };
+    }
+
+    #createMenuDataRow(dishRecord) {
+        const rowElement = this.#documentReference.createElement(HtmlTagName.TR);
+        rowElement.className = ClassName.ROW_DATA;
+
+        rowElement.appendChild(this.#createDishCell(dishRecord));
+        rowElement.appendChild(this.#createIngredientsCell(dishRecord));
+        rowElement.appendChild(this.#createCuisineCell(dishRecord));
+        rowElement.appendChild(this.#createNarrativeCell(dishRecord));
+
+        return rowElement;
+    }
+
+    #createResponsiveHeaderRow() {
+        const rowElement = this.#documentReference.createElement(HtmlTagName.TR);
+        rowElement.className = ClassName.ROW_MOBILE_HEADER;
+
+        rowElement.appendChild(this.#createResponsiveHeaderCell(MenuColumnLabel.DISH));
+        rowElement.appendChild(this.#createResponsiveHeaderCell(MenuColumnLabel.INGREDIENTS));
+        rowElement.appendChild(this.#createResponsiveHeaderCell(MenuColumnLabel.CUISINE));
+        rowElement.appendChild(this.#createResponsiveHeaderCell(MenuColumnLabel.STORY));
+
+        return rowElement;
+    }
+
+    #createResponsiveHeaderCell(columnLabelText) {
+        const headerCellElement = this.#documentReference.createElement(HtmlTagName.TH);
+        headerCellElement.className = ClassName.MOBILE_HEADER_CELL;
+
+        if (HtmlAttributeName.SCOPE && TableHeaderScopeValue.COLUMN) {
+            headerCellElement.setAttribute(HtmlAttributeName.SCOPE, TableHeaderScopeValue.COLUMN);
+        }
+
+        headerCellElement.textContent = typeof columnLabelText === "string"
+            ? columnLabelText
+            : TextContent.EMPTY;
+
+        return headerCellElement;
     }
 
     #createDishCell(dishRecord) {

--- a/tests/integration/menuFilters.integration.test.js
+++ b/tests/integration/menuFilters.integration.test.js
@@ -23,7 +23,9 @@ const CssClassName = Object.freeze({
   FILTER_CLEAR: "menu-filter-clear",
   FILTER_LIST: "menu-filter-list",
   FILTER_OPTION: "menu-filter-option",
-  EMPTY_ROW: "menu-row--empty"
+  EMPTY_ROW: "menu-row--empty",
+  DATA_ROW: "menu-row--data",
+  MOBILE_HEADER_ROW: "menu-row--mobile-header"
 });
 
 const FilterDataAttribute = Object.freeze({
@@ -88,7 +90,7 @@ const FilterInteractionScenarios = Object.freeze([
       selectCuisine("japanese");
       selectIngredient("basil");
     },
-    expectedRowCount: 1,
+    expectedRowCount: 0,
     expectedDishNames: [],
     expectEmptyState: true
   }),
@@ -256,12 +258,23 @@ describe("Menu filters", () => {
     const helpers = createInteractionHelpers();
     arrange(helpers);
 
-    const renderedRows = Array.from(menuTableBodyElement.querySelectorAll(HtmlTagName.TR));
-    expect(renderedRows).toHaveLength(expectedRowCount);
-
-    const emptyRows = renderedRows.filter((rowElement) =>
-      rowElement.classList.contains(CssClassName.EMPTY_ROW)
+    const headerRows = Array.from(
+      menuTableBodyElement.querySelectorAll(`.${CssClassName.MOBILE_HEADER_ROW}`)
     );
+    const dataRows = Array.from(
+      menuTableBodyElement.querySelectorAll(`.${CssClassName.DATA_ROW}`)
+    );
+    const emptyRows = Array.from(
+      menuTableBodyElement.querySelectorAll(`.${CssClassName.EMPTY_ROW}`)
+    );
+
+    expect(dataRows).toHaveLength(expectedRowCount);
+
+    if (expectedRowCount > 0) {
+      expect(headerRows).toHaveLength(expectedRowCount);
+    } else {
+      expect(headerRows).toHaveLength(0);
+    }
 
     if (expectEmptyState) {
       expect(emptyRows).toHaveLength(1);
@@ -270,13 +283,9 @@ describe("Menu filters", () => {
       expect(emptyRows).toHaveLength(0);
     }
 
-    const renderedDishRows = renderedRows.filter(
-      (rowElement) => !rowElement.classList.contains(CssClassName.EMPTY_ROW)
-    );
-
     for (const expectedName of expectedDishNames) {
       expect(
-        renderedDishRows.some((rowElement) => rowElement.textContent.includes(expectedName))
+        dataRows.some((rowElement) => rowElement.textContent.includes(expectedName))
       ).toBe(true);
     }
   });

--- a/tests/integration/navigationMenu.integration.test.js
+++ b/tests/integration/navigationMenu.integration.test.js
@@ -28,6 +28,10 @@ const MenuCellClassName = Object.freeze({
   LABEL: "menu-cell__label"
 });
 
+const MenuRowSelector = Object.freeze({
+  DATA: ".menu-row--data"
+});
+
 const NavigationScenarioDescription = Object.freeze({
   GAME_BUTTON: "clicking the game button requests the allergy screen",
   MENU_BUTTON: "clicking the menu button requests the menu screen"
@@ -248,14 +252,19 @@ describe("MenuView", () => {
       menuView.updateSelectedAllergen({});
     }
 
-    const rowElements = menuTableBodyElement.querySelectorAll("tr");
-    expect(rowElements).toHaveLength(SampleDishes.length);
+    const dataRowElements = menuTableBodyElement.querySelectorAll(MenuRowSelector.DATA);
+    expect(dataRowElements).toHaveLength(SampleDishes.length);
 
-    const firstRowText = rowElements[0].textContent;
+    const [firstDataRowElement] = dataRowElements;
+    if (!firstDataRowElement) {
+      throw new Error("Menu data row not rendered");
+    }
+
+    const firstRowText = firstDataRowElement.textContent;
     expect(firstRowText).toContain(SampleDishes[0].name);
     expect(firstRowText).toContain(SampleDishes[0].narrative);
 
-    const cuisineBadgeElement = rowElements[0].querySelector(".menu-cuisine-badge");
+    const cuisineBadgeElement = firstDataRowElement.querySelector(".menu-cuisine-badge");
     expect(cuisineBadgeElement.textContent).toContain(SampleDishes[0].cuisine);
 
     const highlightedIngredients = Array.from(
@@ -297,11 +306,11 @@ describe("MenuView", () => {
 
     menuView.updateSelectedAllergen({});
 
-    const firstRowElement = menuTableBodyElement.querySelector("tr");
+    const firstRowElement = menuTableBodyElement.querySelector(MenuRowSelector.DATA);
     expect(firstRowElement).not.toBeNull();
 
     if (!firstRowElement) {
-      throw new Error("Menu row not rendered");
+      throw new Error("Menu data row not rendered");
     }
 
     const targetCellElement = firstRowElement.querySelector(cellSelector);


### PR DESCRIPTION
## Summary
- update MenuView rendering to insert mobile header rows before each dish and reuse shared builders
- restyle the narrow breakpoint menu layout to display header rows with the existing pink background and stack data cells cleanly
- align integration tests with the new per-dish row structure while keeping behavioral assertions intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1e28a767c8327861b2708b8b54666