### PR TITLE
Remove menu label separator for mobile menu layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1063,8 +1063,31 @@ body[data-screen="menu"] #screen-menu { display: block }
 
 .menu-table tbody tr:last-child td { border-bottom: none; }
 
-.menu-cell__label {
-    display: none;
+.menu-table tbody td > .menu-cell__label {
+    margin: 0;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    line-height: 1.2;
+}
+
+@media (min-width: 768px) {
+    .menu-table tbody td > .menu-cell__label {
+        display: none;
+    }
+}
+
+@media (max-width: 767px) {
+    .menu-table tbody td {
+        padding: clamp(16px, 4vw, 24px) clamp(14px, 4vw, 22px);
+    }
+
+    .menu-table tbody td > .menu-cell__label {
+        display: block;
+        margin-bottom: clamp(8px, 2.8vw, 14px);
+        font-size: clamp(11px, 3vw, 12px);
+    }
 }
 
 .menu-dish-heading {


### PR DESCRIPTION
## Summary
- remove the menu label pseudo-element separator in the mobile table
- adjust mobile padding and label margins so labels and values remain balanced

## Testing
- manual visual check at 414px viewport using Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68d1ea5f5b6c8327897d165d028c9c9b