### PR TITLE
Add mobile filter controls to responsive menu headers

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -250,6 +250,44 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         text-align: left;
     }
 
+    .menu-row--mobile-header .menu-mobile-header-cell > .menu-header-cell {
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+
+    .menu-row--mobile-header .menu-header-toggle {
+        width: 100%;
+        justify-content: space-between;
+        padding: 12px 16px;
+        border: 2px solid #000;
+        border-radius: 16px;
+        background: #fff;
+        box-shadow: 2px 2px 0 #000;
+        font-size: clamp(12px, 3.2vw, 14px);
+    }
+
+    .menu-row--mobile-header .menu-header-toggle::after {
+        margin-left: auto;
+    }
+
+    .menu-row--mobile-header .menu-filter-panel {
+        position: static;
+        top: auto;
+        right: auto;
+        width: 100%;
+        max-width: none;
+        margin: 0;
+        padding: 16px;
+        box-shadow: none;
+        border-width: 2px;
+    }
+
+    .menu-row--mobile-header .menu-filter-panel.is-open {
+        display: flex;
+    }
+
     .menu-row--data {
         display: block;
         width: 100%;


### PR DESCRIPTION
## Plan
- Reuse the existing ingredient and cuisine filter controls when rendering responsive menu header rows.
- Update the small-screen layout so the toggles and their panels display cleanly inside each mobile header row.
- Ensure filter controls remain available when no dishes match and reattach correctly when the viewport crosses the desktop breakpoint.

## Summary
- Cache the desktop header filter containers, relocate them into the responsive header row on mobile, and restore them on wider viewports while listening for media-query changes.
- Inject the mobile header row ahead of empty states when required and ensure only one row carries the filters per render.
- Enhance the mobile CSS so header toggles and filter panels stack within `.menu-row--mobile-header` without revealing the `<thead>`.

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d20bdb9f288327ba91eaf19d201901