### PR TITLE
Add build-time allergen summary and SEO copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ npm test
 The Jest harness is configured for a jsdom environment so the integration tests can verify canvas rendering and gameplay
 flows. All test files live inside the `tests/` directory and are grouped into `unit` and `integration` subdirectories.
 
+## Update the allergen summary
+
+The crawler-friendly food allergy summary that appears inside the `<noscript>` block on the main screen is generated at
+build time. Run the following command whenever entries in `data/allergens.json`, `data/dishes.json`, or related
+ingredient catalogs change:
+
+```bash
+npm run build:summary
+```
+
+The script loads the JSON catalogs, counts dishes per allergen, and refreshes the static summary so that the SEO copy
+mirrors the latest allergen education data.
+
 ## Avatar customization
 
 Players can personalize the result card by choosing from six built-in avatars: Sunny Girl, Curious Girl, Adventurous
@@ -46,5 +59,5 @@ different option is picked.
 
 ## License
 
-This project is proprietary software. All rights reserved by Marco Polo Research Lab.  
+This project is proprietary software. All rights reserved by Marco Polo Research Lab.
 See the [LICENSE](./LICENSE) file for details.

--- a/index.html
+++ b/index.html
@@ -78,6 +78,28 @@
             <h2 class="title" id="allergy-title">Pick your allergens</h2>
             <p class="muted">Choose anything that might cause trouble. You can change this later.</p>
             <p class="muted">Spin the allergy wheel to win 10 hearts!</p>
+            <!-- GENERATED_ALLERGY_SUMMARY_START -->
+            <noscript class="seo-summary-wrapper">
+                <section aria-labelledby="allergy-summary-title" class="seo-summary">
+                    <h2 id="allergy-summary-title">Food Allergy Quick Reference</h2>
+                    <p>This food allergy quick reference keeps the Allergy Wheel menu aligned with real allergen data so families can plan ahead.</p>
+                    <p>The allergen education checklist below shows how many dishes may trigger each allergen in the Allergy Wheel catalog.</p>
+                    <ul class="seo-summary-list">
+                        <li><strong>🥜 Peanuts</strong> — 18 dishes in the Allergy Wheel menu trigger this allergen alert, including Peanut Pad Thai, PB&amp;J Sandwich, and Spicy Peanut Noodles.</li>
+                        <li><strong>🌰 Tree Nuts</strong> — 18 dishes in the Allergy Wheel menu trigger this allergen alert, including Pesto Pasta, Walnut Pesto Penne, and Cashew Chicken.</li>
+                        <li><strong>⚪️ Sesame</strong> — 41 dishes in the Allergy Wheel menu trigger this allergen alert, including Falafel Wrap, California Roll, and Egg Fried Rice.</li>
+                        <li><strong>🦐 Shellfish</strong> — 33 dishes in the Allergy Wheel menu trigger this allergen alert, including Peanut Pad Thai, Shrimp Tacos, and Clam Chowder.</li>
+                        <li><strong>🥛 Milk / Dairy</strong> — 106 dishes in the Allergy Wheel menu trigger this allergen alert, including Margherita Pizza, Italian Sausage Penne, and Chicken Tikka Masala.</li>
+                        <li><strong>🥚 Egg</strong> — 50 dishes in the Allergy Wheel menu trigger this allergen alert, including Peanut Pad Thai, Egg Fried Rice, and Chicken Katsu Curry.</li>
+                        <li><strong>🫘 Soy</strong> — 53 dishes in the Allergy Wheel menu trigger this allergen alert, including Peanut Pad Thai, Egg Fried Rice, and Spicy Peanut Noodles.</li>
+                        <li><strong>🌾 Wheat / Gluten</strong> — 138 dishes in the Allergy Wheel menu trigger this allergen alert, including Margherita Pizza, Italian Sausage Penne, and Falafel Wrap.</li>
+                        <li><strong>🌭 Italian Sausage (Pork/Spices)</strong> — 17 dishes in the Allergy Wheel menu trigger this allergen alert, including Italian Sausage Penne, Italian Sausage Pizza, and Sausage Lasagna.</li>
+                        <li><strong>🐟 Fish</strong> — 45 dishes in the Allergy Wheel menu trigger this allergen alert, including California Roll, Green Curry, and Tamago Nigiri.</li>
+                    </ul>
+                    <p>Review this food allergy FAQ before spinning the Allergy Wheel to stay confident about every allergen alert.</p>
+                </section>
+            </noscript>
+            <!-- GENERATED_ALLERGY_SUMMARY_END -->
             <div class="grid allergen-grid" id="allergy-list">
                 <button
                     aria-disabled="true"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Interactive allergy wheel game",
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand",
+    "build:summary": "node scripts/build-summary.mjs"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://allergy.mprlab.com/sitemap.xml

--- a/scripts/build-summary.mjs
+++ b/scripts/build-summary.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const SUMMARY_START_MARKER = "<!-- GENERATED_ALLERGY_SUMMARY_START -->";
+const SUMMARY_END_MARKER = "<!-- GENERATED_ALLERGY_SUMMARY_END -->";
+const SUMMARY_SECTION_TITLE = "Food Allergy Quick Reference";
+const SUMMARY_SECTION_HEADING_ID = "allergy-summary-title";
+const SUMMARY_INTRO_PARAGRAPH =
+    "This food allergy quick reference keeps the Allergy Wheel menu aligned with real allergen data so families can plan ahead.";
+const SUMMARY_SECOND_PARAGRAPH =
+    "The allergen education checklist below shows how many dishes may trigger each allergen in the Allergy Wheel catalog.";
+const SUMMARY_OUTRO_PARAGRAPH =
+    "Review this food allergy FAQ before spinning the Allergy Wheel to stay confident about every allergen alert.";
+const SUMMARY_LIST_CLASS = "seo-summary-list";
+const SUMMARY_SECTION_CLASS = "seo-summary";
+const SUMMARY_NOSCRIPT_CLASS = "seo-summary-wrapper";
+const SUMMARY_LIST_INTRO_PHRASE = "including";
+const ZERO_DISHES_MESSAGE =
+    "No dishes currently flag this allergen in the Allergy Wheel menu, so the food allergy catalog shows a safe lane here.";
+const DATA_DIRECTORY_NAME = "data";
+const DISHES_FILE_NAME = "dishes.json";
+const ALLERGENS_FILE_NAME = "allergens.json";
+const INGREDIENTS_FILE_NAME = "ingredients.json";
+const NORMALIZATION_FILE_NAME = "normalization.json";
+const TARGET_INDEX_FILE_NAME = "index.html";
+const SUMMARY_LINE_INDENT = "            ";
+const MAX_EXAMPLE_DISHES = 3;
+
+const HTML_ENTITY_MAP = Object.freeze(
+    new Map([
+        ["&", "&amp;"],
+        ["<", "&lt;"],
+        [">", "&gt;"],
+        ['"', "&quot;"],
+        ["'", "&#39;"],
+    ]),
+);
+
+async function main() {
+    const rootDirectoryPath = resolveRootDirectory();
+    const dataDirectoryPath = path.join(rootDirectoryPath, DATA_DIRECTORY_NAME);
+    const targetIndexPath = path.join(rootDirectoryPath, TARGET_INDEX_FILE_NAME);
+
+    const [dishCatalog, allergenCatalog, ingredientCatalog, normalizationCatalog] = await Promise.all([
+        loadJsonFile(path.join(dataDirectoryPath, DISHES_FILE_NAME)),
+        loadJsonFile(path.join(dataDirectoryPath, ALLERGENS_FILE_NAME)),
+        loadJsonFile(path.join(dataDirectoryPath, INGREDIENTS_FILE_NAME)),
+        loadJsonFile(path.join(dataDirectoryPath, NORMALIZATION_FILE_NAME)),
+    ]);
+
+    const ingredientToAllergenMap = buildIngredientToAllergenMap(ingredientCatalog);
+    const compiledNormalizationRules = compileNormalizationRules(normalizationCatalog);
+
+    const allergenSummaries = computeAllergenSummaries({
+        allergenCatalog,
+        dishCatalog,
+        ingredientToAllergenMap,
+        compiledNormalizationRules,
+    });
+
+    const summaryHtml = createSummaryHtml(allergenSummaries);
+    await injectSummaryIntoIndex({
+        indexFilePath: targetIndexPath,
+        summaryHtml,
+    });
+}
+
+function resolveRootDirectory() {
+    const scriptFilePath = fileURLToPath(import.meta.url);
+    const scriptDirectory = path.dirname(scriptFilePath);
+    return path.resolve(scriptDirectory, "..");
+}
+
+async function loadJsonFile(filePath) {
+    const fileContent = await readFile(filePath, "utf8");
+    return JSON.parse(fileContent);
+}
+
+function buildIngredientToAllergenMap(ingredientCatalog) {
+    const ingredientToAllergenMap = new Map();
+    if (!Array.isArray(ingredientCatalog)) {
+        return ingredientToAllergenMap;
+    }
+
+    for (const ingredientRecord of ingredientCatalog) {
+        if (!ingredientRecord || typeof ingredientRecord !== "object") {
+            continue;
+        }
+        const ingredientName = normalizeTextValue(ingredientRecord.name);
+        const allergenToken = normalizeTextValue(ingredientRecord.allergen);
+        if (ingredientName && allergenToken) {
+            ingredientToAllergenMap.set(ingredientName, allergenToken);
+        }
+    }
+
+    return ingredientToAllergenMap;
+}
+
+function compileNormalizationRules(normalizationCatalog) {
+    const compiledRules = [];
+    if (!Array.isArray(normalizationCatalog)) {
+        return compiledRules;
+    }
+
+    for (const normalizationEntry of normalizationCatalog) {
+        if (!normalizationEntry || typeof normalizationEntry !== "object") {
+            continue;
+        }
+
+        const patternSource = String(normalizationEntry.pattern || "");
+        const patternFlags = String(normalizationEntry.flags || "");
+        const allergenToken = normalizeTextValue(normalizationEntry.token);
+
+        if (!patternSource || !allergenToken) {
+            continue;
+        }
+
+        const compiledMatcher = new RegExp(patternSource, patternFlags);
+        compiledRules.push({
+            allergenToken,
+            compiledMatcher,
+        });
+    }
+
+    return compiledRules;
+}
+
+function computeAllergenSummaries({
+    allergenCatalog,
+    dishCatalog,
+    ingredientToAllergenMap,
+    compiledNormalizationRules,
+}) {
+    const dishesByAllergenToken = new Map();
+    if (Array.isArray(allergenCatalog)) {
+        for (const allergenRecord of allergenCatalog) {
+            if (!allergenRecord || typeof allergenRecord !== "object") {
+                continue;
+            }
+            const allergenToken = normalizeTextValue(allergenRecord.token);
+            if (allergenToken && !dishesByAllergenToken.has(allergenToken)) {
+                dishesByAllergenToken.set(allergenToken, []);
+            }
+        }
+    }
+
+    if (Array.isArray(dishCatalog)) {
+        for (const dishRecord of dishCatalog) {
+            if (!dishRecord || typeof dishRecord !== "object") {
+                continue;
+            }
+
+            const dishAllergenTokens = determineDishAllergens({
+                dishRecord,
+                ingredientToAllergenMap,
+                compiledNormalizationRules,
+            });
+
+            for (const allergenToken of dishAllergenTokens) {
+                if (!dishesByAllergenToken.has(allergenToken)) {
+                    dishesByAllergenToken.set(allergenToken, []);
+                }
+                const allergenDishList = dishesByAllergenToken.get(allergenToken);
+                allergenDishList.push(dishRecord);
+            }
+        }
+    }
+
+    const allergenSummaries = [];
+    if (Array.isArray(allergenCatalog)) {
+        for (const allergenRecord of allergenCatalog) {
+            if (!allergenRecord || typeof allergenRecord !== "object") {
+                continue;
+            }
+
+            const allergenToken = normalizeTextValue(allergenRecord.token);
+            const allergenLabel = String(allergenRecord.label || "");
+            const allergenEmoji = String(allergenRecord.emoji || "");
+            const matchedDishes = dishesByAllergenToken.get(allergenToken) || [];
+
+            const deduplicatedDishes = deduplicateDishesById(matchedDishes);
+            const exampleDishNames = deduplicatedDishes
+                .slice(0, MAX_EXAMPLE_DISHES)
+                .map((dishEntry) => String(dishEntry.name || ""))
+                .filter((dishName) => dishName);
+
+            allergenSummaries.push({
+                allergenToken,
+                allergenLabel,
+                allergenEmoji,
+                dishCount: deduplicatedDishes.length,
+                exampleDishNames,
+            });
+        }
+    }
+
+    return allergenSummaries;
+}
+
+function determineDishAllergens({ dishRecord, ingredientToAllergenMap, compiledNormalizationRules }) {
+    const detectedAllergenTokens = new Set();
+    const ingredientList = Array.isArray(dishRecord.ingredients) ? dishRecord.ingredients : [];
+
+    for (const ingredientNameRaw of ingredientList) {
+        const normalizedIngredientName = normalizeTextValue(ingredientNameRaw);
+        if (!normalizedIngredientName) {
+            continue;
+        }
+
+        if (ingredientToAllergenMap.has(normalizedIngredientName)) {
+            detectedAllergenTokens.add(ingredientToAllergenMap.get(normalizedIngredientName));
+            continue;
+        }
+
+        for (const normalizationRule of compiledNormalizationRules) {
+            if (normalizationRule.compiledMatcher.test(ingredientNameRaw)) {
+                detectedAllergenTokens.add(normalizationRule.allergenToken);
+            }
+        }
+    }
+
+    return detectedAllergenTokens;
+}
+
+function deduplicateDishesById(dishList) {
+    const seenIdentifiers = new Set();
+    const deduplicatedDishes = [];
+
+    for (const dishRecord of dishList) {
+        const dishIdentifier = normalizeTextValue(dishRecord && dishRecord.id);
+        if (!dishIdentifier || seenIdentifiers.has(dishIdentifier)) {
+            continue;
+        }
+        seenIdentifiers.add(dishIdentifier);
+        deduplicatedDishes.push(dishRecord);
+    }
+
+    return deduplicatedDishes;
+}
+
+function createSummaryHtml(allergenSummaries) {
+    const summaryLines = [];
+    summaryLines.push(`<noscript class="${SUMMARY_NOSCRIPT_CLASS}">`);
+    summaryLines.push(
+        `    <section aria-labelledby="${SUMMARY_SECTION_HEADING_ID}" class="${SUMMARY_SECTION_CLASS}">`,
+    );
+    summaryLines.push(`        <h2 id="${SUMMARY_SECTION_HEADING_ID}">${escapeHtml(SUMMARY_SECTION_TITLE)}</h2>`);
+    summaryLines.push(`        <p>${escapeHtml(SUMMARY_INTRO_PARAGRAPH)}</p>`);
+    summaryLines.push(`        <p>${escapeHtml(SUMMARY_SECOND_PARAGRAPH)}</p>`);
+    summaryLines.push(`        <ul class="${SUMMARY_LIST_CLASS}">`);
+
+    for (const allergenSummary of allergenSummaries) {
+        summaryLines.push(`            ${createAllergenListItem(allergenSummary)}`);
+    }
+
+    summaryLines.push("        </ul>");
+    summaryLines.push(`        <p>${escapeHtml(SUMMARY_OUTRO_PARAGRAPH)}</p>`);
+    summaryLines.push("    </section>");
+    summaryLines.push("</noscript>");
+
+    return summaryLines
+        .map((line) => `${SUMMARY_LINE_INDENT}${line}`)
+        .join("\n");
+}
+
+function createAllergenListItem(allergenSummary) {
+    const { allergenEmoji, allergenLabel, dishCount, exampleDishNames } = allergenSummary;
+    const escapedLabel = escapeHtml(allergenLabel);
+    const emojiPart = escapeHtml(allergenEmoji);
+    const dishCountText = formatDishCount(dishCount);
+
+    if (dishCount === 0) {
+        return `<li><strong>${emojiPart} ${escapedLabel}</strong> — ${escapeHtml(ZERO_DISHES_MESSAGE)}</li>`;
+    }
+
+    const escapedExamples = exampleDishNames.map((name) => escapeHtml(name));
+    const exampleList = formatExampleList(escapedExamples);
+    const exampleText = exampleList
+        ? ` ${SUMMARY_LIST_INTRO_PHRASE} ${exampleList}.`
+        : "";
+    const allergenAlertText = `${dishCountText} in the Allergy Wheel menu trigger this allergen alert,`;
+    const escapedAlertText = escapeHtml(allergenAlertText);
+
+    return `<li><strong>${emojiPart} ${escapedLabel}</strong> — ${escapedAlertText}${exampleText}</li>`;
+}
+
+function formatDishCount(dishCount) {
+    if (dishCount === 1) {
+        return "1 dish";
+    }
+    return `${dishCount} dishes`;
+}
+
+function formatExampleList(exampleNames) {
+    if (exampleNames.length === 0) {
+        return "";
+    }
+    if (exampleNames.length === 1) {
+        return exampleNames[0];
+    }
+    if (exampleNames.length === 2) {
+        return `${exampleNames[0]} and ${exampleNames[1]}`;
+    }
+    const leadingExamples = exampleNames.slice(0, exampleNames.length - 1).join(", ");
+    const finalExample = exampleNames[exampleNames.length - 1];
+    return `${leadingExamples}, and ${finalExample}`;
+}
+
+function escapeHtml(textValue) {
+    return String(textValue).replace(/[&<>"']/g, (character) => HTML_ENTITY_MAP.get(character) || character);
+}
+
+function normalizeTextValue(rawValue) {
+    return typeof rawValue === "string" ? rawValue.trim().toLowerCase() : "";
+}
+
+async function injectSummaryIntoIndex({ indexFilePath, summaryHtml }) {
+    const existingIndexContent = await readFile(indexFilePath, "utf8");
+    const startMarkerIndex = existingIndexContent.indexOf(SUMMARY_START_MARKER);
+    const endMarkerIndex = existingIndexContent.indexOf(SUMMARY_END_MARKER);
+
+    if (startMarkerIndex === -1 || endMarkerIndex === -1 || endMarkerIndex < startMarkerIndex) {
+        throw new Error(
+            `Summary markers not found in ${indexFilePath}. Add ${SUMMARY_START_MARKER} and ${SUMMARY_END_MARKER} placeholders.`,
+        );
+    }
+
+    const contentBeforeMarker = existingIndexContent.slice(0, startMarkerIndex + SUMMARY_START_MARKER.length);
+    const contentAfterMarker = existingIndexContent.slice(endMarkerIndex);
+    const updatedIndexContent = `${contentBeforeMarker}\n${summaryHtml}\n${SUMMARY_LINE_INDENT}${contentAfterMarker}`;
+
+    await writeFile(indexFilePath, updatedIndexContent);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://allergy.mprlab.com/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- generate a noscript allergen summary directly in `index.html` so crawlers see data-aligned copy
- add a Node build script plus npm helper to regenerate the summary from the JSON catalogs
- document the regeneration workflow in the README for future catalog updates

## Testing
- npm run build:summary
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d245751060832793792e96e481fa65