### PR TITLE
Refine mobile menu layout and tests

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -222,23 +222,26 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         background: inherit;
     }
 
-    .menu-row--mobile-header {
+    .menu-mobile-filter-container {
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        margin-bottom: 16px;
+    }
+
+    .menu-mobile-filter-container .menu-row--mobile-header {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         gap: 12px;
         align-items: center;
         padding: 12px 16px;
         background: #ffdfe9;
-        border-bottom: 2px solid #ffd6e3;
+        border: 2px solid #ffd6e3;
+        border-radius: 18px;
         box-sizing: border-box;
-        margin-top: 16px;
     }
 
-    .menu-row--mobile-header:first-child {
-        margin-top: 0;
-    }
-
-    .menu-row--mobile-header .menu-mobile-header-cell {
+    .menu-mobile-filter-container .menu-mobile-header-cell {
         display: block;
         margin: 0;
         padding: 0;
@@ -250,14 +253,14 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         text-align: left;
     }
 
-    .menu-row--mobile-header .menu-mobile-header-cell > .menu-header-cell {
+    .menu-mobile-filter-container .menu-mobile-header-cell > .menu-header-cell {
         display: flex;
         flex-direction: column;
         align-items: stretch;
         gap: 12px;
     }
 
-    .menu-row--mobile-header .menu-header-toggle {
+    .menu-mobile-filter-container .menu-header-toggle {
         width: 100%;
         justify-content: space-between;
         padding: 12px 16px;
@@ -268,11 +271,11 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         font-size: clamp(12px, 3.2vw, 14px);
     }
 
-    .menu-row--mobile-header .menu-header-toggle::after {
+    .menu-mobile-filter-container .menu-header-toggle::after {
         margin-left: auto;
     }
 
-    .menu-row--mobile-header .menu-filter-panel {
+    .menu-mobile-filter-container .menu-filter-panel {
         position: static;
         top: auto;
         right: auto;
@@ -284,7 +287,7 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         border-width: 2px;
     }
 
-    .menu-row--mobile-header .menu-filter-panel.is-open {
+    .menu-mobile-filter-container .menu-filter-panel.is-open {
         display: flex;
     }
 
@@ -292,6 +295,10 @@ header h1 { margin: 0; font-size: clamp(18px, 2.2vw, 28px) }
         display: block;
         width: 100%;
         box-sizing: border-box;
+    }
+
+    .menu-row--data:not(:first-child) {
+        margin-top: 16px;
     }
 
     .menu-row--data td {
@@ -912,6 +919,10 @@ body[data-screen="menu"] #screen-menu { display: block }
     overflow: hidden;
 }
 
+.menu-mobile-filter-container {
+    display: none;
+}
+
 .menu-table {
     width: 100%;
     border-collapse: separate;
@@ -1087,6 +1098,7 @@ body[data-screen="menu"] #screen-menu { display: block }
 }
 
 @media (min-width: 768px) {
+    .menu-mobile-filter-container { display: none; }
     .menu-row--mobile-header { display: none; }
 }
 


### PR DESCRIPTION
## Summary
- update MenuView rendering to mount a single responsive filter header outside the table body on mobile while restoring desktop filters when needed
- refresh mobile menu styling with a dedicated filter container and spacing so only data rows remain inside the tbody
- extend menu integration tests with viewport helpers to confirm stacked mobile cards render without header rows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d24a9695988327b9793a5d4da6bb0b