### PR TITLE
chore(allergy_wheel): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 
 .idea/
 node_modules/
+# Managed by gix gitignore workflow
+.env
+.env.*
+qodana.yaml
+tools/
+bin/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).